### PR TITLE
Fix dontpastetheai.com to be dontquotetheai.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
       <p>Next time someone drops an amazing set of unedited LLM text in your DMs, your Slack, your code review, anywhere
         really, send them this:</p>
       <p class="u-center u-mt-lg"><button type="button" class="url-tag-big" onclick="copyTag(this)"
-          aria-label="Copy dontquotetheai.com to clipboard">dontpastetheai.com</button></p>
+          aria-label="Copy dontquotetheai.com to clipboard">dontquotetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">Click to copy. No explanation needed — they'll know.</p>
     </section>
 


### PR DESCRIPTION

### Description of the Change

Seems like the text that gets copy isn't the correct domain


### Why Should This Be here?

Quick fix

### Benefits

TBD

### Possible Drawbacks

N/A

### Applicable Issues


Ignore the template for the quick fix