### PR TITLE
chore: sort language picker alphabetically and enforce it in CI

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -42,6 +42,29 @@ jobs:
           curl -fsSL "https://cdn.jsdelivr.net/fontsource/fonts/noto-sans-devanagari@latest/devanagari-400-normal.ttf" -o ~/.local/share/fonts/noto-sans-devanagari.ttf || true
           fc-cache -f
 
+      - name: Sort translations.json alphabetically
+        run: |
+          node -e "
+            const fs = require('fs');
+            const p = 'assets/translations.json';
+            const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+            const sorted = [...data.languages].sort((a, b) => a.code.localeCompare(b.code));
+            const changed = sorted.some((s, i) => s.code !== data.languages[i].code);
+            if (!changed) { console.log('translations.json already sorted.'); process.exit(0); }
+            data.languages = sorted;
+            fs.writeFileSync(p, JSON.stringify(data, null, 2) + '\n');
+            console.log('translations.json was not sorted, fixed.');
+          "
+          if [ -n "$(git diff assets/translations.json)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add assets/translations.json
+            git commit -m "chore: sort translations.json alphabetically"
+            git push
+            echo "::error::translations.json was not sorted. Fixed and pushed. CI will re-run."
+            exit 1
+          fi
+
       - name: Sync hreflang blocks
         run: node scripts/sync-hreflang.mjs
 

--- a/assets/translations.json
+++ b/assets/translations.json
@@ -1,10 +1,58 @@
 {
   "languages": [
     {
+      "code": "de",
+      "hreflang": "de",
+      "label": "DE — Deutsch",
+      "file": "de.html"
+    },
+    {
       "code": "en",
       "hreflang": "en",
       "label": "EN — English",
       "file": "index.html"
+    },
+    {
+      "code": "es",
+      "hreflang": "es",
+      "label": "ES — Español",
+      "file": "es.html"
+    },
+    {
+      "code": "fa",
+      "hreflang": "fa",
+      "label": "FA — فارسی",
+      "file": "fa.html"
+    },
+    {
+      "code": "fr",
+      "hreflang": "fr",
+      "label": "FR — Français",
+      "file": "fr.html"
+    },
+    {
+      "code": "hu",
+      "hreflang": "hu",
+      "label": "HU — Magyar",
+      "file": "hu.html"
+    },
+    {
+      "code": "id",
+      "hreflang": "id",
+      "label": "ID — Bahasa Indonesia",
+      "file": "id.html"
+    },
+    {
+      "code": "it",
+      "hreflang": "it",
+      "label": "IT — Italiano",
+      "file": "it.html"
+    },
+    {
+      "code": "ja",
+      "hreflang": "ja",
+      "label": "JA — 日本語",
+      "file": "ja.html"
     },
     {
       "code": "ko",
@@ -13,10 +61,16 @@
       "file": "ko.html"
     },
     {
-      "code": "uk",
-      "hreflang": "uk",
-      "label": "UK — Українська",
-      "file": "uk.html"
+      "code": "ne",
+      "hreflang": "ne",
+      "label": "NE — नेपाली",
+      "file": "ne.html"
+    },
+    {
+      "code": "pl",
+      "hreflang": "pl",
+      "label": "PL — Polski",
+      "file": "pl.html"
     },
     {
       "code": "pt-br",
@@ -31,54 +85,6 @@
       "file": "ru.html"
     },
     {
-      "code": "zh-tw",
-      "hreflang": "zh-TW",
-      "label": "ZH — 繁體中文 (台灣)",
-      "file": "zh-tw.html"
-    },
-    {
-      "code": "zh-cn",
-      "hreflang": "zh-CN",
-      "label": "ZH — 简体中文",
-      "file": "zh-cn.html"
-    },
-    {
-      "code": "it",
-      "hreflang": "it",
-      "label": "IT — Italiano",
-      "file": "it.html"
-    },
-    {
-      "code": "es",
-      "hreflang": "es",
-      "label": "ES — Español",
-      "file": "es.html"
-    },
-    {
-      "code": "fr",
-      "hreflang": "fr",
-      "label": "FR — Français",
-      "file": "fr.html"
-    },
-    {
-      "code": "ja",
-      "hreflang": "ja",
-      "label": "JA — 日本語",
-      "file": "ja.html"
-    },
-    {
-      "code": "hu",
-      "hreflang": "hu",
-      "label": "HU — Magyar",
-      "file": "hu.html"
-    },
-    {
-      "code": "tr",
-      "hreflang": "tr",
-      "label": "TR — Türkçe",
-      "file": "tr.html"
-    },
-    {
       "code": "sr",
       "hreflang": "sr",
       "label": "SR — Српски",
@@ -91,34 +97,28 @@
       "file": "sr-latn.html"
     },
     {
-      "code": "de",
-      "hreflang": "de",
-      "label": "DE — Deutsch",
-      "file": "de.html"
+      "code": "tr",
+      "hreflang": "tr",
+      "label": "TR — Türkçe",
+      "file": "tr.html"
     },
     {
-      "code": "id",
-      "hreflang": "id",
-      "label": "ID — Bahasa Indonesia",
-      "file": "id.html"
+      "code": "uk",
+      "hreflang": "uk",
+      "label": "UK — Українська",
+      "file": "uk.html"
     },
     {
-      "code": "ne",
-      "hreflang": "ne",
-      "label": "NE — नेपाली",
-      "file": "ne.html"
+      "code": "zh-cn",
+      "hreflang": "zh-CN",
+      "label": "ZH — 简体中文",
+      "file": "zh-cn.html"
     },
     {
-      "code": "fa",
-      "hreflang": "fa",
-      "label": "FA — فارسی",
-      "file": "fa.html"
-    },
-    {
-      "code": "pl",
-      "hreflang": "pl",
-      "label": "PL — Polski",
-      "file": "pl.html"
+      "code": "zh-tw",
+      "hreflang": "zh-TW",
+      "label": "ZH — 繁體中文 (台灣)",
+      "file": "zh-tw.html"
     }
   ]
 }

--- a/scripts/check-translations.mjs
+++ b/scripts/check-translations.mjs
@@ -68,6 +68,19 @@ const languages = translations.languages;
 // Quick lookup helpers
 const langByFile = new Map(languages.map((l) => [l.file, l]));
 
+// --- Check 0: alphabetical order by code ---
+const codes = languages.map((l) => l.code);
+const sorted = [...codes].sort();
+for (let i = 0; i < codes.length; i++) {
+  if (codes[i] !== sorted[i]) {
+    err(
+      "assets/translations.json",
+      `languages not sorted by code: "${codes[i]}" at index ${i}, expected "${sorted[i]}"`
+    );
+    break;
+  }
+}
+
 // --- Check 9: registered HTML files (no orphans) ---
 const rootHtml = readdirSync(REPO_ROOT).filter(
   (f) => f.endsWith(".html") && statSync(join(REPO_ROOT, f)).isFile()


### PR DESCRIPTION
## Non-translation PR

**What changed and why:**

The language dropdown order was whatever order people happened to append their entry in, so the picker looked random to anyone scrolling it. Sorted `assets/translations.json` by `code` so the dropdown comes out alphabetical, and added two things to keep it that way.

`scripts/check-translations.mjs` now reports an error if the array is out of order, so PRs get told before merge.

`sync.yml` fixes it instead of just complaining. If a merge to main arrives unsorted, the workflow sorts the file, commits, pushes, then exits 1. That push re-triggers the workflow, and the second pass finds it sorted and carries on to the hreflang and OG steps. The commit deliberately has no `[skip ci]` since the re-run is the point.

- [x] The **Validate translations** GitHub Action passed on this PR.
