### PR TITLE
Make the Korean angry lede actually insulting

### DIFF
--- a/angry/ko.html
+++ b/angry/ko.html
@@ -71,7 +71,7 @@
         </label>
       </div>
       <h1><span class="yell">시1발 AI</span> 답 좀<br>그대로 붙여넣지 마.</h1>
-      <p class="lede">답변이 <span class="marker">“Claude가 이렇게 말했어:”</span>로 시작하거나 <span class="marker">ChatGPT가 생성한 800단어짜리 글</span>을 커밋했다면, 축하한다. 네 뇌가 우동사리라는 걸 직접 증명했네. 하늘에서 다윈도 널 보며 흐뭇해할 거다. <strong>제발 번식은 하지 마</strong>.</p>
+      <p class="lede">답변이 <span class="marker">“Claude가 이렇게 말했어:”</span>로 시작하거나 <span class="marker">ChatGPT가 생성한 800단어짜리 글</span>을 커밋했다면, 축하한다. 네 뇌가 우동사리라는 걸 직접 증명했네. 하늘에서 다윈도 널 보며 흐뭇해할 거다. <strong>제발 너는 애 낳지 말아줘</strong>.</p>
     </header>
 
     <section>


### PR DESCRIPTION
Closes #32.

`angry/ko.html` — one line:

```diff
-<strong>제발 번식은 하지 마</strong>.
+<strong>제발 너는 애 낳지 말아줘</strong>.
```

### First: c7cb569 was fixing my mistake, not breaking my translation

I should be straight about where this line came from. My original Korean was `제발 똥 좀 그만 만들어` — roughly *"please stop making shit"*. I had read **reproduce** as *produce more output*, so I translated it as a jab at the AI-generated text itself: what you're churning out is a turd, stop.

Re-reading the paragraph with the Darwin sentence sitting right in front of it, that's plainly wrong. The line is about not passing your DNA on. So the sync commit didn't flatten a good localization — it caught a genuine mistranslation, and 번식 restored the meaning the original actually has.

What's left to fix is only the register.

### Why 번식 still doesn't land in Korean

- **번식** is a biology-textbook word, used for animals, plants and bacteria. Applied to a person it reads clinical rather than crude, so a Korean reader stops to puzzle over the word choice instead of feeling the jab.
- English *reproduce* works because it carries the clinical and the insulting register in one word. Korean splits those across different words, and 번식 is the clinical half.
- That deflates the punchline of a deliberately vulgar sentence (`시1발`, `우동사리` ≈ *"your brain is udon noodles"*).

### What the new line does

- **애 낳지 마** ("don't have kids") is how a Korean speaker actually delivers this as an insult, and it still means *don't reproduce* — so the Darwin setup keeps paying off. Meaning preserved, register fixed.
- **말아줘** is mock-polite, which mirrors the *"Please"* of the original better than a flat imperative. Switching to a pleading tone right after two lines of harsh 반말 sharpens the jab by contrast rather than softening it.
- **너는** ("you, specifically") points the line at the reader, which is what makes the natural-selection joke land.

### Notes

- Only the angry version has this line; the smooth `ko.html` is untouched.
- `assets/og-image-ko.svg` does not contain this text, so no OG regeneration is needed.
- `node scripts/check-translations.mjs` → `0 errors, 0 warnings`.
