### PR TITLE
Add Romanian translation (ro)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Spiritual cousin of [nohello.net](https://nohello.net) and [dontasktoask.com](ht
 | Bahasa Indonesia (`id`) | ✅ [id.html](id.html) | ✅ [angry/id.html](angry/id.html) | ✅ | [@Arceister] |
 | 한국어 (`ko`) | ✅ [ko.html](ko.html) | ✅ [angry/ko.html](angry/ko.html) | ✅ | [@kaq6822] |
 | فارسی (`fa`) | ✅ [fa.html](fa.html) | ✅ [angry/fa.html](angry/fa.html) | ✅ | [@am2mcu] |
+| Română (`ro`) | ✅ [ro.html](ro.html) | ✅ [angry/ro.html](angry/ro.html) | ✅ | [@dorneanu] |
 
 [@webknjaz]: https://github.com/sponsors/webknjaz
 [@alexeev-prog]: https://github.com/alexeev-prog
@@ -54,6 +55,7 @@ Spiritual cousin of [nohello.net](https://nohello.net) and [dontasktoask.com](ht
 [@Arceister]: https://github.com/Arceister
 [@kaq6822]: https://github.com/kaq6822
 [@am2mcu]: https://github.com/am2mcu
+[@dorneanu]: https://github.com/dorneanu
 [@ymaldor1]: https://github.com/ymaldor1
 
 Want to suggest a language? Open an issue or just send the PR (even a half-finished one). We can iterate. Huge thanks to everyone in the Maintainer column above who took the time to make this page work in their language.
@@ -77,6 +79,7 @@ A teacher-facing page at `/student/` for students who hand in AI-generated work 
 | नेपाली (`ne`) | ✅ [`/student/ne`](student/ne.html) | Machine Translated |
 | Polski (`pl`) | ✅ [`/student/pl`](student/pl.html) | Machine Translated |
 | Português (BR) (`pt-br`) | ✅ [`/student/pt-br`](student/pt-br.html) | Machine Translated |
+| Română (`ro`) | ✅ [`/student/ro`](student/ro.html) | [@dorneanu] |
 | Русский (`ru`) | ✅ [`/student/ru`](student/ru.html) | Machine Translated |
 | Српски (`sr`) | ✅ [`/student/sr`](student/sr.html) | Machine Translated |
 | Srpski (lat.) (`sr-latn`) | ✅ [`/student/sr-latn`](student/sr-latn.html) | Machine Translated |

--- a/angry/de.html
+++ b/angry/de.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/es.html
+++ b/angry/es.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/fa.html
+++ b/angry/fa.html
@@ -66,6 +66,7 @@
     <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
     <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
     <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+    <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
     <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
     <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
     <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/fr.html
+++ b/angry/fr.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/hu.html
+++ b/angry/hu.html
@@ -42,6 +42,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/id.html
+++ b/angry/id.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/index.html
+++ b/angry/index.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/it.html
+++ b/angry/it.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/ja.html
+++ b/angry/ja.html
@@ -46,6 +46,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/ko.html
+++ b/angry/ko.html
@@ -48,6 +48,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/ne.html
+++ b/angry/ne.html
@@ -46,6 +46,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/pl.html
+++ b/angry/pl.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/pt-br.html
+++ b/angry/pt-br.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/ro.html
+++ b/angry/ro.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Nu-mi mai băga AI-ul pe gât.</title>
   <meta name="description" content="Dacă răspunsul tău e o grămadă de căcat generat de un LLM, tu ești problema.">
-  <meta property="og:title" content="Nu lipi AI-ul">
+  <meta property="og:title" content="Nu-mi mai băga AI-ul pe gât.">
   <meta property="og:description" content="Dacă răspunsul tău e o grămadă de căcat generat de un LLM, tu ești problema.">
   <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-ro.png">
   <meta property="og:image:width" content="1200">
@@ -59,14 +59,13 @@
 
     <header>
       <div class="doc-meta">
-        <span>Fii fript în limba ta:</span>
+        <span>Fii făcut praf în limba ta:</span>
         <label class="lang" aria-label="Limbă">
           <select data-lang-select>
             <option>RO — Română</option>
           </select>
         </label>
-      </div>
-      <h1>Termină cu lipitul<br>răspunsului dr*cului de la <span class="yell">AI</span>.</h1>
+      <h1>Nu-mi mai da copy-paste<br>de la <span class="yell">AI</span>, dr*cu' să te ia.</h1>
       <p class="lede">Dacă răspunsul tău începe cu <span class="marker">„Uite ce a zis Claude:”</span> sau bagi
         <span class="marker">opt sute de cuvinte generate de ChatGPT</span>, felicitări: tocmai ai dovedit că
         creierul tău e de decor, Darwin ar fi mândru. <strong>Te rog nu te reproduce</strong>.
@@ -76,8 +75,8 @@
     <section>
       <h2>Ce tocmai ai făcut:</h2>
       <p>Cineva ți-a pus o întrebare reală, una ADEVĂRATĂ. Avea contextul și cele mai bune intenții. A venit la tine,
-        <em>special</em> (ce onoare). Apoi tu ai luat întrebarea, ai băgat-o într-o casetă de prompt și ai lipit
-        rezultatul înapoi. Pun pariu că te-ai simțit super productiv și deștept și toate cele... Îmi pare rău să-ți
+        <em>special</em> (ce onoare). Apoi tu ai luat întrebarea, ai băgat-o într-o casetă de prompt și ai copiat
+        rezultatul înapoi. Pun pariu că te-ai simțit super productiv și deștept și-așa mai departe... Îmi pare rău să-ți
         stric surpriza, nu ai devenit cu nimic mai deștept, tocmai ai dovedit că nu există nicio diferență între a te
         întreba pe tine și a întreba AI-ul.
       </p>
@@ -105,7 +104,7 @@
 
     <section>
       <h2>Asta e profund lipsit de respect</h2>
-      <p>Persoana căreia i-ai răspuns <strong>are același AI ca tine</strong>. Dacă ar fi vrut răspunsul generic de
+      <p>Persoana căreia i-ai răspuns <strong>are la dispoziție același AI ca și tine</strong>. Dacă ar fi vrut răspunsul generic de
         la LLM, l-ar fi avut în câteva secunde fără să vorbească cu tine, ceea ce, apropo, e <em>mai simplu</em>. Dar
         te-a întrebat pe tine pentru că te voia <em>pe tine</em>. Părerea ta. Experiența ta. Gustul tău. Tot ce un
         model nu are.
@@ -117,14 +116,14 @@
       </p>
 
       <p>Nu ești mai deștept decât nimeni. Doar faci pe cineva să-și piardă respectul pentru tine în timp real,
-        într-un mod greu de reparat. Ți-ai vândut părerea pe o frază de fortune cookie și ți-ai văzut de viață.
+        într-un mod greu de reparat. Ți-ai vândut părerea pe o vorbă goală și ți-ai văzut de viață.
       </p>
 
       <p>Dacă tot faci asta, atunci <em>de ce ar mai întreba cineva ceva de la tine?</em></p>
     </section>
 
     <div class="shout">
-      Lipitul modelului<br>nu e <span>gândire</span>.
+      Lipitul modelului <br>nu e <span>gândirea</span>.
     </div>
 
     <section>
@@ -139,8 +138,8 @@
         <li>Scrie-ți propriul răspuns. Trei propoziții de-ale <em>tale</em> bat de fiecare dată trei paragrafe de
           balegă. Nimeni n-a zis vreodată „Băi frate... Aș fi vrut ca răspunsul ăla să fie mai lung și mai robotic”.
         </li>
-        <li>Dacă chiar trebuie să citezi modelul, bine, sunt lucruri bune acolo! Doar explică <em>de ce</em>. „Am
-          întrebat Claude și partea asta chiar se confirmă:”, e ok! Măcar ai citit ce s-a întâmplat acolo, tot te mai
+        <li>Dacă chiar trebuie să citezi modelul, bine, sunt lucruri bune acolo! Doar explică <em>de ce</em>. „L-am
+          întrebat pe Claude și partea asta chiar se confirmă:”, e ok! Măcar ai citit ce s-a întâmplat acolo, tot te mai
           plăcem
         </li>
         <li>Dacă n-ai nimic de adăugat, <strong>nu spune nimic</strong>. Tăcerea e și ea o contribuție. Sau spune
@@ -153,8 +152,8 @@
       <p>Nu, nu vrei. Încerci să <em>pari</em> util fără să faci munca de a fi util. Există o diferență acolo.
       </p>
       <p>A ajuta înseamnă să <strong>citești</strong> cu atenție, să <strong>gândești</strong>, și să
-        <strong>răspunzi</strong> cu ceva ce doar tu ai fi putut spune, sau măcar șlefui. Lipitul de chestii de la un
-        AI îi spune persoanei că întrebarea ei nu a meritat timpul tău, doar pe al unui chatbot. Cum te-ai simți?
+        <strong>răspunzi</strong> cu ceva ce doar tu ai fi putut spune, sau măcar șlefui. Să copiezi de la un AI
+        înseamnă să-i spui persoanei că întrebarea ei nu a meritat timpul tău, doar pe al unui chatbot. Cum te-ai simți?
       </p>
     </section>
 
@@ -163,13 +162,13 @@
       <p>Folosește instrumentele. Folosește-le zilnic. Folosește-le ca să faci ciorne mai repede, să fii mai creativ,
         să înveți mai mult, să te deblochezi. Grozav. Exact pentru asta există. <strong>Rezultatul e un punct de
           plecare, nu un livrabil.</strong> Tratează-l ca prima ciornă a unui stagiar, pentru că exact asta e.
-        Editează-l. Taie din el. Contrazice-l. Fă-l al tău, sau nu-l trimite.
+        Editează-l. Taie din el. Contrazice-l. Fă-l al tău sau nu-l trimite deloc.
       </p>
     </section>
 
     <section>
       <h2>Cum folosești asta?</h2>
-      <p>Data viitoare când cineva bagă un zid de text needitat de la un LLM în DM-urile tale, pe Slack, într-un code
+      <p>Data viitoare când cineva bagă o mizerie de text needitat de la un LLM în DM-urile tale, pe Slack, într-un code
         review, sincer oriunde, trimite-i asta:</p>
       <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
           data-copy-aria="Copiază {domain} în clipboard" data-copied-text="copiat!">dontpastetheai.com</button></p>

--- a/angry/ro.html
+++ b/angry/ro.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="ro">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nu-mi mai băga AI-ul pe gât.</title>
+  <meta name="description" content="Dacă răspunsul tău e o grămadă de căcat generat de un LLM, tu ești problema.">
+  <meta property="og:title" content="Nu lipi AI-ul">
+  <meta property="og:description" content="Dacă răspunsul tău e o grămadă de căcat generat de un LLM, tu ești problema.">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-ro.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ro_RO">
+  <meta property="og:url" content="https://dontpastetheai.com/angry/ro.html">
+  <link rel="canonical" href="https://dontpastetheai.com/angry/ro.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image-ro.png">
+  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Special+Elite&family=JetBrains+Mono:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="../styles.css">
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/angry/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/angry/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/angry/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/angry/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/angry/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/angry/hu.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/angry/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/angry/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/angry/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/angry/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/angry/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/angry/">
+  <!-- hreflang:end -->
+  <script src="../assets/translations.js" defer></script>
+  <script src="../assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>Fii fript în limba ta:</span>
+        <label class="lang" aria-label="Limbă">
+          <select data-lang-select>
+            <option>RO — Română</option>
+          </select>
+        </label>
+      </div>
+      <h1>Termină cu lipitul<br>răspunsului dr*cului de la <span class="yell">AI</span>.</h1>
+      <p class="lede">Dacă răspunsul tău începe cu <span class="marker">„Uite ce a zis Claude:”</span> sau bagi
+        <span class="marker">opt sute de cuvinte generate de ChatGPT</span>, felicitări: tocmai ai dovedit că
+        creierul tău e de decor, Darwin ar fi mândru. <strong>Te rog nu te reproduce</strong>.
+      </p>
+    </header>
+
+    <section>
+      <h2>Ce tocmai ai făcut:</h2>
+      <p>Cineva ți-a pus o întrebare reală, una ADEVĂRATĂ. Avea contextul și cele mai bune intenții. A venit la tine,
+        <em>special</em> (ce onoare). Apoi tu ai luat întrebarea, ai băgat-o într-o casetă de prompt și ai lipit
+        rezultatul înapoi. Pun pariu că te-ai simțit super productiv și deștept și toate cele... Îmi pare rău să-ți
+        stric surpriza, nu ai devenit cu nimic mai deștept, tocmai ai dovedit că nu există nicio diferență între a te
+        întreba pe tine și a întreba AI-ul.
+      </p>
+
+      <p><em>Ghici pe cine înlocuiește AI-ul primul?</em></p>
+
+      <blockquote>
+        <span class="exhibit-label">În caz că nu a fost clar, iată ce ai răspuns:</span>
+        Întrebare excelentă! Există mai mulți factori-cheie de luat în calcul atunci când abordăm acest subiect
+        nuanțat, la care cineva chiar s-a obosit să se gândească. Hai să-l descompunem pas cu pas, din nou:<br><br>
+        1. <strong>Înțelegerea contextului</strong> — E important să stabilim mai întâi o bază solidă, pentru că
+        exact asta ai întrebat de la bun început<br>
+        2. <strong>Aspecte-cheie</strong> — Când evaluezi asta, trebuie să ții cont că... Sunt sigur că nimic din ce
+        urmează să spun nu ți-a trecut vreodată prin cap<br>
+        3. <strong>Bune practici</strong> — Experții din industrie recomandă, în general, această căutare pe Google
+        pe care ai fi putut-o face în 3 secunde<br><br>
+
+        În concluzie, răspunsul depinde în cele din urmă de situația ta specifică. Sper că a ajutat, campionule!
+        Spune-mi dacă vrei să detaliez vreunul dintre aceste puncte.
+
+        <em>Uau... Iluminator, noul Buddha umblă printre noi. Mersi pentru perla asta de înțelepciune pe care aș fi
+          putut-o obține și singur.</em>
+      </blockquote>
+    </section>
+
+    <section>
+      <h2>Asta e profund lipsit de respect</h2>
+      <p>Persoana căreia i-ai răspuns <strong>are același AI ca tine</strong>. Dacă ar fi vrut răspunsul generic de
+        la LLM, l-ar fi avut în câteva secunde fără să vorbească cu tine, ceea ce, apropo, e <em>mai simplu</em>. Dar
+        te-a întrebat pe tine pentru că te voia <em>pe tine</em>. Părerea ta. Experiența ta. Gustul tău. Tot ce un
+        model nu are.
+      </p>
+
+      <p>Ce ai trimis în schimb a fost: <span class="marker">„N-am avut răbdare să-ți citesc întrebarea cum trebuie
+          și să-ți răspund efectiv, deci uite, asta a zis robotul”</span>. E echivalentul conversațional al
+        <strong>redirecționării unui email</strong>.
+      </p>
+
+      <p>Nu ești mai deștept decât nimeni. Doar faci pe cineva să-și piardă respectul pentru tine în timp real,
+        într-un mod greu de reparat. Ți-ai vândut părerea pe o frază de fortune cookie și ți-ai văzut de viață.
+      </p>
+
+      <p>Dacă tot faci asta, atunci <em>de ce ar mai întreba cineva ceva de la tine?</em></p>
+    </section>
+
+    <div class="shout">
+      Lipitul modelului<br>nu e <span>gândire</span>.
+    </div>
+
+    <section>
+      <h2>Soluția e destul de simplă</h2>
+      <ol>
+        <li>Poți folosi AI. E un instrument bun. E acolo ca să fie folosit, dar pentru numele sănătății noastre
+          mintale colective, <strong>CITEȘTE</strong> ce a zis modelul. Tot. Da, chiar și listele, codul, totul...
+        </li>
+        <li>Decide ce e util și ce nu. Modelele sunt sigure pe ele într-un fel care nu are nicio legătură cu a avea
+          dreptate. Jumătate e probabil greșit, generic, sau ambele. Și asta când nu e halucinație pură.
+        </li>
+        <li>Scrie-ți propriul răspuns. Trei propoziții de-ale <em>tale</em> bat de fiecare dată trei paragrafe de
+          balegă. Nimeni n-a zis vreodată „Băi frate... Aș fi vrut ca răspunsul ăla să fie mai lung și mai robotic”.
+        </li>
+        <li>Dacă chiar trebuie să citezi modelul, bine, sunt lucruri bune acolo! Doar explică <em>de ce</em>. „Am
+          întrebat Claude și partea asta chiar se confirmă:”, e ok! Măcar ai citit ce s-a întâmplat acolo, tot te mai
+          plăcem
+        </li>
+        <li>Dacă n-ai nimic de adăugat, <strong>nu spune nimic</strong>. Tăcerea e și ea o contribuție. Sau spune
+          „N-am nimic de adăugat”. O să economisească timpul tuturor.</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>„Dar eu vreau să ajut!”</h2>
+      <p>Nu, nu vrei. Încerci să <em>pari</em> util fără să faci munca de a fi util. Există o diferență acolo.
+      </p>
+      <p>A ajuta înseamnă să <strong>citești</strong> cu atenție, să <strong>gândești</strong>, și să
+        <strong>răspunzi</strong> cu ceva ce doar tu ai fi putut spune, sau măcar șlefui. Lipitul de chestii de la un
+        AI îi spune persoanei că întrebarea ei nu a meritat timpul tău, doar pe al unui chatbot. Cum te-ai simți?
+      </p>
+    </section>
+
+    <section>
+      <h2>Site-ul ăsta nu e anti-AI.</h2>
+      <p>Folosește instrumentele. Folosește-le zilnic. Folosește-le ca să faci ciorne mai repede, să fii mai creativ,
+        să înveți mai mult, să te deblochezi. Grozav. Exact pentru asta există. <strong>Rezultatul e un punct de
+          plecare, nu un livrabil.</strong> Tratează-l ca prima ciornă a unui stagiar, pentru că exact asta e.
+        Editează-l. Taie din el. Contrazice-l. Fă-l al tău, sau nu-l trimite.
+      </p>
+    </section>
+
+    <section>
+      <h2>Cum folosești asta?</h2>
+      <p>Data viitoare când cineva bagă un zid de text needitat de la un LLM în DM-urile tale, pe Slack, într-un code
+        review, sincer oriunde, trimite-i asta:</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+          data-copy-aria="Copiază {domain} în clipboard" data-copied-text="copiat!">dontpastetheai.com</button></p>
+      <p class="u-center u-small u-muted u-mt-md">Click pentru a copia.</p>
+    </section>
+
+    <section>
+      <h2>Prea intens?</h2>
+      <p>Fără griji. Preferi să trimiți versiunea sigură pentru birou? O avem și pe aia:</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" data-variant-toggle href="../">← Sunt sclavul
+          capitalismului</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— cu sinceritate,<br> probabil toată lumea</div>
+      <small>văr spiritual al <a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> &amp;
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a>.<br>pagina asta
+        a fost scrisă de <a href="https://github.com/khaosdoctor/dontquotetheai/issues/31" target="_blank" rel="noopener">un tip oarecare</a> (nebunie, nu?). Și chiar corectată.
+      </small>
+    </div>
+
+    <div class="footer">
+      <p><em>Dacă cineva ți-a trimis acest link, nu te <a href="https://www.youtube.com/watch?v=xzpndHtdl9A"
+            target="_blank" rel="noopener">supăra</a> pe el. A venit cu bune intenții. Citește-l, respiră, și
+          scrie-ți singur următorul răspuns.</em></p>
+      <p>Satiră (în caz că ți-a scăpat). Liber de distribuit, remixat și tradus —
+        <a href="https://github.com/khaosdoctor/dontpastetheai" target="_blank" rel="noopener">PR-urile sunt
+          binevenite pe GitHub</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>

--- a/angry/ro.html
+++ b/angry/ro.html
@@ -65,6 +65,7 @@
             <option>RO — Română</option>
           </select>
         </label>
+      </div>
       <h1>Nu-mi mai da copy-paste<br>de la <span class="yell">AI</span>, dr*cu' să te ia.</h1>
       <p class="lede">Dacă răspunsul tău începe cu <span class="marker">„Uite ce a zis Claude:”</span> sau bagi
         <span class="marker">opt sute de cuvinte generate de ChatGPT</span>, felicitări: tocmai ai dovedit că

--- a/angry/ru.html
+++ b/angry/ru.html
@@ -41,6 +41,7 @@
     <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
     <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
     <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+    <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
     <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
     <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
     <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/sr-latn.html
+++ b/angry/sr-latn.html
@@ -43,6 +43,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/sr.html
+++ b/angry/sr.html
@@ -43,6 +43,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/tr.html
+++ b/angry/tr.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/uk.html
+++ b/angry/uk.html
@@ -43,6 +43,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/zh-cn.html
+++ b/angry/zh-cn.html
@@ -74,6 +74,7 @@
         <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
         <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
         <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+        <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
         <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
         <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
         <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/angry/zh-tw.html
+++ b/angry/zh-tw.html
@@ -43,6 +43,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">

--- a/assets/og-image-ro.svg
+++ b/assets/og-image-ro.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <rect width="1200" height="630" fill="#ede2c4"/>
+
+  <ellipse cx="1020" cy="95" rx="400" ry="300" fill="#5a3214" opacity="0.08"/>
+  <ellipse cx="120" cy="565" rx="300" ry="200" fill="#5a3214" opacity="0.05"/>
+
+  <text x="600" y="230" text-anchor="middle" font-family="Special Elite" font-size="100" fill="#15120e">Ups, ai lipit</text>
+  <text x="600" y="340" text-anchor="middle" font-family="Special Elite" font-size="100" fill="#15120e"><tspan fill="#a82820">AI</tspan>-ul fără să-l</text>
+  <text x="600" y="450" text-anchor="middle" font-family="Special Elite" font-size="100" fill="#15120e">citești.</text>
+
+  <g transform="translate(740,540) rotate(-1)">
+    <rect x="4" y="4" width="380" height="60" fill="#15120e"/>
+    <rect x="0" y="0" width="380" height="60" fill="#f5d547" stroke="#15120e" stroke-width="3"/>
+    <text x="190" y="44" text-anchor="middle" font-family="Special Elite" font-size="32" fill="#15120e">dontpastetheai.com</text>
+  </g>
+</svg>

--- a/assets/translations.json
+++ b/assets/translations.json
@@ -92,6 +92,13 @@
       "file": "pt-br.html"
     },
     {
+      "code": "ro",
+      "hreflang": "ro",
+      "locale": "ro_RO",
+      "label": "RO — Română",
+      "file": "ro.html"
+    },
+    {
       "code": "ru",
       "hreflang": "ru",
       "locale": "ru_RU",
@@ -233,6 +240,13 @@
         "locale": "pt_BR",
         "label": "PT — Português (BR)",
         "file": "pt-br.html"
+      },
+      {
+        "code": "ro",
+        "hreflang": "ro",
+        "locale": "ro_RO",
+        "label": "RO — Română",
+        "file": "ro.html"
       },
       {
         "code": "ru",

--- a/de.html
+++ b/de.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/es.html
+++ b/es.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/fa.html
+++ b/fa.html
@@ -67,6 +67,7 @@
     <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
     <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
     <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+    <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
     <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
     <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
     <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/fr.html
+++ b/fr.html
@@ -42,6 +42,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/hu.html
+++ b/hu.html
@@ -42,6 +42,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/id.html
+++ b/id.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/it.html
+++ b/it.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/ja.html
+++ b/ja.html
@@ -46,6 +46,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/ko.html
+++ b/ko.html
@@ -48,6 +48,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/ne.html
+++ b/ne.html
@@ -46,6 +46,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/pl.html
+++ b/pl.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/pt-br.html
+++ b/pt-br.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/ro.html
+++ b/ro.html
@@ -4,9 +4,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Nu lipi AI-ul, te rog.</title>
+  <title>Nu copia AI-ul, te rog.</title>
   <meta name="description" content="Dacă cineva te întreabă ceva, trimite-i răspunsul tău. Nu al AI-ului.">
-  <meta property="og:title" content="Nu lipi AI-ul, te rog.">
+  <meta property="og:title" content="Nu copia AI-ul, te rog.">
   <meta property="og:description" content="Dacă cineva te întreabă ceva, trimite-i răspunsul tău. Nu al AI-ului.">
   <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-ro.png">
   <meta property="og:image:width" content="1200">
@@ -66,9 +66,9 @@
           </select>
         </label>
       </div>
-      <h1>Nu lipi<br><span class="yell">AI</span>-ul, te rog.</h1>
+      <h1>Nu copia<br><span class="yell">AI</span>-ul, te rog.</h1>
       <p class="lede">Când cineva te întreabă ceva, vrea răspunsul <em>tău</em>.
-        Nu un zid de <span class="marker">text din ChatGPT</span>. Un răspuns scurt de la un om va valora mereu mai
+        Nu un <span class="marker">talmeș-balmeș de text din ChatGPT</span>. Un răspuns scurt de la un om va valora mereu mai
         mult decât unul de la un robot, chiar dacă robotul are dreptate.</p>
     </header>
 
@@ -76,7 +76,7 @@
       <h2>Ce s-a întâmplat</h2>
       <p>Cineva ți-a pus o întrebare sinceră. Tu ai băgat-o într-un chatbot, ai copiat răspunsul și l-ai trimis mai
         departe. Părea rapid. Părea util. Nu a fost.</p>
-      <p>Poate nu pare, dar persoana de partea cealaltă <strong>are aceleași instrumente ca tine</strong>. Dacă ar fi
+      <p>Poate nu pare, dar persoana de partea cealaltă <strong>are la dispoziție aceleași instrumente ca și tine</strong>. Dacă ar fi
         vrut răspunsul generic, l-ar fi avut în câteva secunde. Te-a întrebat <em>pe tine</em> pentru că voia părerea
         ta... Contextul tău, gustul tău, judecata ta.</p>
 
@@ -87,13 +87,13 @@
     <section>
       <h2>Fă asta în schimb</h2>
       <ol>
-        <li>Poți folosi AI. Serios! E un instrument grozav pentru ciorne. Doar <strong>citește ce ți-a dat
-          </strong>, apoi scrie-ți propria versiune, sau șlefuiește textul. Nu fi un intermediar între el și
+        <li>Poți folosi AI. Serios! E un instrument grozav pentru ciorne. Doar <strong>citește ce ți-a dat</strong>,
+          apoi scrie-ți propria versiune, sau șlefuiește textul. Nu fi un intermediar între el și
           răspuns.</li>
         <li>Ia partea care chiar răspunde la întrebare și ignoră restul. E nevoie doar de trei propoziții, iar chiar
           dacă sunt copiate, măcar le-ai citit.</li>
         <li>Dacă o parte din răspunsul modelului chiar e utilă, citeaz-o și explică <em>de ce</em>.
-          <span class="marker"><em>„Am întrebat Claude și partea asta are sens:”</em></span>.
+          <span class="marker"><em>„L-am întrebat pe Claude și partea asta are sens:”</em></span>.
         </li>
         <li>Dacă nu ai nimic de adăugat, spune asta. <span class="marker"><em>„Nu am o părere anume
               aici”</em></span>. Tăcerea e și ea o opțiune.
@@ -103,7 +103,7 @@
 
     <section>
       <h2>Vrei să trimiți asta cuiva?</h2>
-      <p>Dacă cineva tocmai a dat drumul la un zid de text generat de un LLM în DM-uri, pe Slack sau într-un code
+      <p>Dacă cineva tocmai a dat drumul la un talmeș-balmeș de text generat de un LLM în DM-uri, pe Slack sau într-un code
         review, îi poți trimite acest link.</p>
       <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
           data-copy-aria="Copiază {domain} în clipboard" data-copied-text="copiat!">dontpastetheai.com</button></p>
@@ -113,9 +113,9 @@
     <section>
       <h2>Vrei o versiune mai dură?</h2>
       <p>Dacă preferi să trimiți o versiune cu ceva mai multă <em>pasiune</em> implicată, te-am prins!</p>
-      <p class="u-center u-mt-lg"><a class="cta-angry" data-variant-toggle href="angry/index.html">Vreau să ard
-          poduri 🔥</a></p>
-      <p class="u-center u-small u-muted u-mt-md">S-ar putea să nu aibă cea mai bună primire la muncă, dar treaba ta
+      <p class="u-center u-mt-lg"><a class="cta-angry" data-variant-toggle href="angry/index.html">Vreau să rup
+          relațiile 🔥</a></p>
+      <p class="u-center u-small u-muted u-mt-md">S-ar putea să nu fie foarte apreciată la birou, dar e alegerea ta
       </p>
     </section>
 

--- a/ro.html
+++ b/ro.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="ro">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nu lipi AI-ul, te rog.</title>
+  <meta name="description" content="Dacă cineva te întreabă ceva, trimite-i răspunsul tău. Nu al AI-ului.">
+  <meta property="og:title" content="Nu lipi AI-ul, te rog.">
+  <meta property="og:description" content="Dacă cineva te întreabă ceva, trimite-i răspunsul tău. Nu al AI-ului.">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-ro.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ro_RO">
+  <meta property="og:url" content="https://dontpastetheai.com/ro.html">
+  <link rel="canonical" href="https://dontpastetheai.com/ro.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image-ro.png">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Special+Elite&family=JetBrains+Mono:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/hu.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/">
+  <!-- hreflang:end -->
+  <script src="assets/translations.js" defer></script>
+  <script src="assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>Preferi altă limbă?</span>
+        <label class="lang" aria-label="Limbă">
+          <select data-lang-select>
+            <option>RO — Română</option>
+          </select>
+        </label>
+      </div>
+      <h1>Nu lipi<br><span class="yell">AI</span>-ul, te rog.</h1>
+      <p class="lede">Când cineva te întreabă ceva, vrea răspunsul <em>tău</em>.
+        Nu un zid de <span class="marker">text din ChatGPT</span>. Un răspuns scurt de la un om va valora mereu mai
+        mult decât unul de la un robot, chiar dacă robotul are dreptate.</p>
+    </header>
+
+    <section>
+      <h2>Ce s-a întâmplat</h2>
+      <p>Cineva ți-a pus o întrebare sinceră. Tu ai băgat-o într-un chatbot, ai copiat răspunsul și l-ai trimis mai
+        departe. Părea rapid. Părea util. Nu a fost.</p>
+      <p>Poate nu pare, dar persoana de partea cealaltă <strong>are aceleași instrumente ca tine</strong>. Dacă ar fi
+        vrut răspunsul generic, l-ar fi avut în câteva secunde. Te-a întrebat <em>pe tine</em> pentru că voia părerea
+        ta... Contextul tău, gustul tău, judecata ta.</p>
+
+      <p>Lumea e plină de oameni care nu vor să citească sau să gândească lucrurile până la capăt. Nu fi unul dintre
+        ei.</p>
+    </section>
+
+    <section>
+      <h2>Fă asta în schimb</h2>
+      <ol>
+        <li>Poți folosi AI. Serios! E un instrument grozav pentru ciorne. Doar <strong>citește ce ți-a dat
+          </strong>, apoi scrie-ți propria versiune, sau șlefuiește textul. Nu fi un intermediar între el și
+          răspuns.</li>
+        <li>Ia partea care chiar răspunde la întrebare și ignoră restul. E nevoie doar de trei propoziții, iar chiar
+          dacă sunt copiate, măcar le-ai citit.</li>
+        <li>Dacă o parte din răspunsul modelului chiar e utilă, citeaz-o și explică <em>de ce</em>.
+          <span class="marker"><em>„Am întrebat Claude și partea asta are sens:”</em></span>.
+        </li>
+        <li>Dacă nu ai nimic de adăugat, spune asta. <span class="marker"><em>„Nu am o părere anume
+              aici”</em></span>. Tăcerea e și ea o opțiune.
+        </li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>Vrei să trimiți asta cuiva?</h2>
+      <p>Dacă cineva tocmai a dat drumul la un zid de text generat de un LLM în DM-uri, pe Slack sau într-un code
+        review, îi poți trimite acest link.</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+          data-copy-aria="Copiază {domain} în clipboard" data-copied-text="copiat!">dontpastetheai.com</button></p>
+      <p class="u-center u-small u-muted u-mt-md">Click pentru a copia.</p>
+    </section>
+
+    <section>
+      <h2>Vrei o versiune mai dură?</h2>
+      <p>Dacă preferi să trimiți o versiune cu ceva mai multă <em>pasiune</em> implicată, te-am prins!</p>
+      <p class="u-center u-mt-lg"><a class="cta-angry" data-variant-toggle href="angry/index.html">Vreau să ard
+          poduri 🔥</a></p>
+      <p class="u-center u-small u-muted u-mt-md">S-ar putea să nu aibă cea mai bună primire la muncă, dar treaba ta
+      </p>
+    </section>
+
+    <section>
+      <h2>Ești profesor?</h2>
+      <p>Dacă studenții tăi îți trimit o lucrare sau un proiect generat de AI, le poți trimite acest link:</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" data-student-toggle href="student/">Trimite-i la ore</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— cu... Drag? <br>Toată lumea</div>
+      <small>văr spiritual al <a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> &amp;
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a>.<br>scris
+        de un tip oarecare (<a href="https://github.com/khaosdoctor/dontquotetheai/issues/31" target="_blank" rel="noopener">crede sau nu</a>). Exact ca pe vremuri.</small>
+    </div>
+
+    <div class="footer">
+      <p><em>Dacă cineva ți-a trimis acest link: vrea să te gândești la asta. Citește, respiră, și scrie tu
+          următorul răspuns.</em></p>
+      <p>Acest site e satiră (în caz că nu ai observat) — Simte-te liber să copiezi, modifici, traduci etc.
+        <a href="https://github.com/khaosdoctor/dontquotetheai" target="_blank" rel="noopener">PR-urile sunt
+          binevenite pe GitHub</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>

--- a/ru.html
+++ b/ru.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -80,6 +80,12 @@
     <loc>https://dontpastetheai.com/angry/pt-br.html</loc>
   </url>
   <url>
+    <loc>https://dontpastetheai.com/ro.html</loc>
+  </url>
+  <url>
+    <loc>https://dontpastetheai.com/angry/ro.html</loc>
+  </url>
+  <url>
     <loc>https://dontpastetheai.com/ru.html</loc>
   </url>
   <url>
@@ -159,6 +165,9 @@
   </url>
   <url>
     <loc>https://dontpastetheai.com/student/pt-br.html</loc>
+  </url>
+  <url>
+    <loc>https://dontpastetheai.com/student/ro.html</loc>
   </url>
   <url>
     <loc>https://dontpastetheai.com/student/ru.html</loc>

--- a/sr-latn.html
+++ b/sr-latn.html
@@ -43,6 +43,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/sr.html
+++ b/sr.html
@@ -43,6 +43,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/student/de.html
+++ b/student/de.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/es.html
+++ b/student/es.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/fa.html
+++ b/student/fa.html
@@ -47,6 +47,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/fr.html
+++ b/student/fr.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/hu.html
+++ b/student/hu.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/id.html
+++ b/student/id.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/index.html
+++ b/student/index.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/it.html
+++ b/student/it.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/ja.html
+++ b/student/ja.html
@@ -46,6 +46,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/ko.html
+++ b/student/ko.html
@@ -50,6 +50,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/ne.html
+++ b/student/ne.html
@@ -46,6 +46,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/pl.html
+++ b/student/pl.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/pt-br.html
+++ b/student/pt-br.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/ro.html
+++ b/student/ro.html
@@ -176,7 +176,7 @@
         <h1>Nu preda<br />AI-ul, te rog.</h1>
         <p class="lede">
           Când îți cer <em>lucrarea ta</em>, îți cer gândirea ta. Nu un PDF
-          băgat într-un chatbot și copiat înapoi si dupaia trimis mie.
+          băgat într-un chatbot și copiat înapoi și dupaia trimis mie.
           <span class="marker">AI te poate ajuta să lucrezi</span>. Nu poate fi
           el cel care face treaba.
         </p>
@@ -247,7 +247,7 @@
           >
         </p>
         <p>
-          Dar nu preda pur și simplu proiectul cu numele tau pe el. Scopul unei
+          Dar nu preda pur și simplu proiectul cu numele tău pe el. Scopul unei
           teme nu e să produci niște pagini scrise de dragul de a avea ceva
           predat. E să înțelegi ceva suficient de bine încât să poți spune tu
           însuți.

--- a/student/ro.html
+++ b/student/ro.html
@@ -1,150 +1,324 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ro" data-page="student">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nu preda AI-ul, te rog.</title>
+    <meta
+      name="description"
+      content="AI te poate ajuta cu lucrarea ta. Nu poate gândi în locul tău."
+    />
+    <meta property="og:title" content="Nu preda AI-ul, te rog." />
+    <meta
+      property="og:description"
+      content="AI te poate ajuta cu lucrarea ta. Nu poate gândi în locul tău."
+    />
+    <meta
+      property="og:image"
+      content="https://dontpastetheai.com/assets/og-image.png"
+    />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="ro_RO" />
+    <meta
+      property="og:url"
+      content="https://dontpastetheai.com/student/ro.html"
+    />
+    <link rel="canonical" href="https://dontpastetheai.com/student/ro.html" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:image"
+      content="https://dontpastetheai.com/assets/og-image.png"
+    />
+    <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg" />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="../assets/favicon-32.png"
+    />
+    <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Special+Elite&family=JetBrains+Mono:wght@400;500;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+    <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+    <link
+      rel="alternate"
+      hreflang="de"
+      href="https://dontpastetheai.com/student/de.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="en"
+      href="https://dontpastetheai.com/student/"
+    />
+    <link
+      rel="alternate"
+      hreflang="es"
+      href="https://dontpastetheai.com/student/es.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="fa"
+      href="https://dontpastetheai.com/student/fa.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="fr"
+      href="https://dontpastetheai.com/student/fr.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="hu"
+      href="https://dontpastetheai.com/student/hu.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="id"
+      href="https://dontpastetheai.com/student/id.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="it"
+      href="https://dontpastetheai.com/student/it.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="ja"
+      href="https://dontpastetheai.com/student/ja.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="ko"
+      href="https://dontpastetheai.com/student/ko.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="ne"
+      href="https://dontpastetheai.com/student/ne.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="pl"
+      href="https://dontpastetheai.com/student/pl.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="pt-BR"
+      href="https://dontpastetheai.com/student/pt-br.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="ro"
+      href="https://dontpastetheai.com/student/ro.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="ru"
+      href="https://dontpastetheai.com/student/ru.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="sr"
+      href="https://dontpastetheai.com/student/sr.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="sr-Latn"
+      href="https://dontpastetheai.com/student/sr-latn.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="tr"
+      href="https://dontpastetheai.com/student/tr.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="uk"
+      href="https://dontpastetheai.com/student/uk.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="zh-CN"
+      href="https://dontpastetheai.com/student/zh-cn.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="zh-TW"
+      href="https://dontpastetheai.com/student/zh-tw.html"
+    />
+    <link
+      rel="alternate"
+      hreflang="x-default"
+      href="https://dontpastetheai.com/student/"
+    />
+    <!-- hreflang:end -->
+    <script src="../assets/translations.js" defer></script>
+    <script src="../assets/copy.js" defer></script>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Nu preda AI-ul, te rog.</title>
-  <meta name="description" content="AI te poate ajuta cu lucrarea ta. Nu poate gândi în locul tău.">
-  <meta property="og:title" content="Nu preda AI-ul, te rog.">
-  <meta property="og:description" content="AI te poate ajuta cu lucrarea ta. Nu poate gândi în locul tău.">
-  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image.png">
-  <meta property="og:image:width" content="1200">
-  <meta property="og:image:height" content="630">
-  <meta property="og:type" content="website">
-  <meta property="og:locale" content="ro_RO">
-  <meta property="og:url" content="https://dontpastetheai.com/student/ro.html">
-  <link rel="canonical" href="https://dontpastetheai.com/student/ro.html">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image.png">
-  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
-  <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon-32.png">
-  <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link
-    href="https://fonts.googleapis.com/css2?family=Special+Elite&family=JetBrains+Mono:wght@400;500;700;800&display=swap"
-    rel="stylesheet">
-  <link rel="stylesheet" href="../styles.css">
-  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
-  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/student/de.html">
-  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/student/">
-  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/student/es.html">
-  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/student/fa.html">
-  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/student/fr.html">
-  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/student/hu.html">
-  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/student/id.html">
-  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/student/it.html">
-  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/student/ja.html">
-  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/student/ko.html">
-  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
-  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
-  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
-  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
-  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
-  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
-  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
-  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
-  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
-  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">
-  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/student/zh-tw.html">
-  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/student/">
-  <!-- hreflang:end -->
-  <script src="../assets/translations.js" defer></script>
-  <script src="../assets/copy.js" defer></script>
-</head>
+  <body>
+    <main class="sheet">
+      <header>
+        <div class="doc-meta">
+          <span>Preferi altă limbă?</span>
+          <label class="lang" aria-label="Limbă">
+            <select data-lang-select>
+              <option>RO — Română</option>
+            </select>
+          </label>
+        </div>
+        <h1>Nu preda<br />AI-ul, te rog.</h1>
+        <p class="lede">
+          Când îți cer <em>lucrarea ta</em>, îți cer gândirea ta. Nu un PDF
+          băgat într-un chatbot și copiat înapoi si dupaia trimis mie.
+          <span class="marker">AI te poate ajuta să lucrezi</span>. Nu poate fi
+          el cel care face treaba.
+        </p>
+      </header>
 
-<body>
-  <main class="sheet">
+      <section>
+        <h2>Ce s-a întâmplat</h2>
+        <p>
+          Aveai un proiect. Ai băgat PDF-ul într-un instrument AI, i-ai cerut să
+          scrie lucrarea, și ai predat răspunsul fără să-l citești. A fost
+          eficient. A fost și extrem de evident.
+        </p>
+        <p>
+          Nu ai finalizat tema. Ți-ai
+          <strong>externalizat activitatea creierului</strong> și ți-ai pus
+          numele pe rezultat. Referințele nu se potrivesc cu argumentul,
+          argumentul nu sună ca tine, iar uneori răspunsul e greșit cu multă
+          siguranță de sine. Știu. L-am citit.
+        </p>
+        <p>AI a făcut treaba. AI ia nota. <em>Tu nu.</em></p>
+      </section>
 
-    <header>
-      <div class="doc-meta">
-        <span>Preferi altă limbă?</span>
-        <label class="lang" aria-label="Limbă">
-          <select data-lang-select>
-            <option>RO — Română</option>
-          </select>
-        </label>
+      <div class="shout">
+        Subcontractarea creierului tău<br />nu e <span>învățare</span>.
       </div>
-      <h1>Nu preda<br>AI-ul, te rog.</h1>
-      <p class="lede">Când îți cer <em>lucrarea ta</em>, îți cer gândirea ta.
-        Nu un PDF băgat într-un chatbot și lipit înapoi la mine. <span class="marker">AI te poate ajuta să
-          lucrezi</span>. Nu poate fi el cel care face treaba.</p>
-    </header>
 
-    <section>
-      <h2>Ce s-a întâmplat</h2>
-      <p>Aveai un proiect. Ai băgat PDF-ul într-un instrument AI, i-ai cerut să scrie lucrarea, și ai predat
-        răspunsul fără să-l citești. A fost eficient. A fost și extrem de evident.</p>
-      <p>Nu ai finalizat tema. Ți-ai <strong>externalizat activitatea creierului</strong> și ți-ai pus numele pe
-        rezultat. Referințele nu se potrivesc cu argumentul, argumentul nu sună ca tine, iar uneori răspunsul e
-        greșit cu multă siguranță de sine. Știu. L-am citit.</p>
-      <p>AI a făcut treaba. AI ia nota. <em>Tu nu.</em></p>
-    </section>
+      <section>
+        <h2>Fă asta în schimb</h2>
+        <ol>
+          <li>
+            Folosește AI pentru documentare, brainstorming, explicarea unui
+            concept dificil, sau pentru a-ți găsi o direcție. Folosește-l ca
+            instrument, nu ca substitut pentru a avea un punct de vedere.
+          </li>
+          <li>
+            Citește tot ce îți dă. Verifică sursele. Pune la îndoială răspunsul.
+            Modelele pot suna sigure pe ele deși sunt complet greșite, iar
+            numele tău rămâne pe lucrare.
+          </li>
+          <li>
+            Fă argumentul al tău. Decide ce crezi, explică <em>de ce</em>, și
+            folosește dovezi ca să-l susții. Raționamentul tău e tema, nu
+            numărul de paragrafe.
+          </li>
+          <li>
+            Editează până înțelegi fiecare propoziție. Dacă nu poți explica o
+            afirmație fără să întrebi din nou chatbot-ul, nu ești pregătit s-o
+            predai.
+          </li>
+          <li>
+            Fii onest în privința instrumentului. Respectarea regulilor pentru
+            declararea folosirii AI face parte din a face treaba corect. O
+            ciornă neșlefuită, dar cu adevărat a ta, valorează mai mult decât un
+            răspuns lustruit pe care nu l-ai înțeles niciodată.
+          </li>
+        </ol>
+      </section>
 
-    <div class="shout">
-      Subcontractarea creierului tău<br>nu e <span>învățare</span>.
-    </div>
+      <section>
+        <h2>Asta nu e anti-AI</h2>
+        <p>
+          Nu îți cer să te prefaci că aceste instrumente nu există. Folosește-le
+          ca să pui întrebări mai bune, să găsești contraargumente, să testezi o
+          idee, să îmbunătățești o ciornă, și să înveți.
+          <strong
+            >Documentează-te. Gândește. Controlează. Argumentează.
+            Provoacă.</strong
+          >
+        </p>
+        <p>
+          Dar nu preda pur și simplu proiectul cu numele tau pe el. Scopul unei
+          teme nu e să produci niște pagini scrise de dragul de a avea ceva
+          predat. E să înțelegi ceva suficient de bine încât să poți spune tu
+          însuți.
+        </p>
+      </section>
 
-    <section>
-      <h2>Fă asta în schimb</h2>
-      <ol>
-        <li>Folosește AI pentru documentare, brainstorming, explicarea unui concept dificil, sau pentru a-ți găsi o
-          direcție. Folosește-l ca instrument, nu ca substitut pentru a avea un punct de vedere.</li>
-        <li>Citește tot ce îți dă. Verifică sursele. Pune la îndoială răspunsul. Modelele pot suna sigure pe ele deși
-          sunt complet greșite, iar numele tău rămâne pe lucrare.</li>
-        <li>Fă argumentul al tău. Decide ce crezi, explică <em>de ce</em>, și folosește dovezi ca să-l susții.
-          Raționamentul tău e tema, nu numărul de paragrafe.</li>
-        <li>Editează până înțelegi fiecare propoziție. Dacă nu poți explica o afirmație fără să întrebi din nou
-          chatbot-ul, nu ești pregătit s-o predai.</li>
-        <li>Fii onest în privința instrumentului. Respectarea regulilor pentru declararea folosirii AI face parte
-          din a face treaba corect. O ciornă neșlefuită, dar cu adevărat a ta, valorează mai mult decât un răspuns
-          lustruit pe care nu l-ai înțeles niciodată.</li>
-      </ol>
-    </section>
+      <section>
+        <h2>Vrei să trimiți asta cuiva?</h2>
+        <p>
+          Dacă un student a predat o lucrare generată de AI fără s-o citească,
+          trimite-i acest link. Poate data viitoare își ține creierul în
+          proiectul de grup.
+        </p>
+        <p class="u-center u-mt-lg">
+          <button
+            id="copyBtn"
+            type="button"
+            class="url-tag-big"
+            data-copy-aria="Copiază {domain} în clipboard"
+            data-copy-path="/student/ro"
+            data-copied-text="copiat!"
+          >
+            dontpastetheai.com/student
+          </button>
+        </p>
+        <p class="u-center u-small u-muted u-mt-md">Click pentru a copia.</p>
+      </section>
 
-    <section>
-      <h2>Asta nu e anti-AI</h2>
-      <p>Nu îți cer să te prefaci că aceste instrumente nu există. Folosește-le ca să pui întrebări mai bune, să
-        găsești contraargumente, să testezi o idee, să îmbunătățești o ciornă, și să înveți.
-        <strong>Documentează-te. Gândește. Controlează. Argumentează. Provoacă.</strong></p>
-      <p>Dar nu preda pur și simplu proiectul și numi rezultatul munca ta. Scopul unei teme nu e să produci un obiect
-        în formă de document. E să înțelegi ceva suficient de bine încât să poți spune tu însuți.</p>
-    </section>
+      <section>
+        <h2>Cauți originalul?</h2>
+        <p>
+          Pagina principală e pentru oricine lipește răspunsuri de la AI fără să
+          le citească mai întâi.
+        </p>
+        <p class="u-center u-mt-lg">
+          <a class="cta-calm" href="../">Înapoi la Nu copia AI-ul</a>
+        </p>
+      </section>
 
-    <section>
-      <h2>Vrei să trimiți asta cuiva?</h2>
-      <p>Dacă un student a predat o lucrare generată de AI fără s-o citească, trimite-i acest link. Poate data
-        viitoare își ține creierul în proiectul de grup.</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
-          data-copy-aria="Copiază {domain} în clipboard" data-copy-path="/student/ro"
-          data-copied-text="copiat!">dontpastetheai.com/student</button></p>
-      <p class="u-center u-small u-muted u-mt-md">Click pentru a copia.</p>
-    </section>
+      <div class="signature">
+        <div class="name">— cu sinceritate,<br />Profesorul tău dezamăgit</div>
+        <small
+          >văr spiritual al
+          <a href="https://nohello.net" target="_blank" rel="noopener"
+            >nohello.net</a
+          >
+          &amp;
+          <a href="https://dontasktoask.com" target="_blank" rel="noopener"
+            >dontasktoask.com</a
+          >.<br />Scris cu grijă. Corectat înainte de trimitere.</small
+        >
+      </div>
 
-    <section>
-      <h2>Cauți originalul?</h2>
-      <p>Pagina principală e pentru oricine lipește răspunsuri de la AI fără să le citească mai întâi.</p>
-      <p class="u-center u-mt-lg"><a class="cta-calm" href="../">Înapoi la Nu lipi AI-ul</a></p>
-    </section>
-
-    <div class="signature">
-      <div class="name">— cu sinceritate,<br>Profesorul tău dezamăgit</div>
-      <small>văr spiritual al <a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> &amp;
-        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a>.<br>Scris cu
-        grijă. Corectat înainte de trimitere.</small>
-    </div>
-
-    <div class="footer">
-      <p><em>Dacă cineva ți-a trimis acest link: vrea să te gândești la asta. Citește, respiră, și scrie tu
-          următoarea propoziție.</em></p>
-      <p>Acest site e satiră (în caz că nu ai observat) — Simte-te liber să copiezi, modifici, traduci etc.
-        <a href="https://github.com/khaosdoctor/dontquotetheai" target="_blank" rel="noopener">PR-urile sunt
-          binevenite pe GitHub</a>.
-      </p>
-    </div>
-
-  </main>
-</body>
-
+      <div class="footer">
+        <p>
+          <em
+            >Dacă cineva ți-a trimis acest link: vrea să te gândești la asta.
+            Citește, respiră, și scrie tu următoarea propoziție.</em
+          >
+        </p>
+        <p>
+          Acest site e satiră (în caz că nu ai observat) — Simte-te liber să
+          copiezi, modifici, traduci etc.
+          <a
+            href="https://github.com/khaosdoctor/dontquotetheai"
+            target="_blank"
+            rel="noopener"
+            >PR-urile sunt binevenite pe GitHub</a
+          >.
+        </p>
+      </div>
+    </main>
+  </body>
 </html>

--- a/student/ro.html
+++ b/student/ro.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="ro" data-page="student">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nu preda AI-ul, te rog.</title>
+  <meta name="description" content="AI te poate ajuta cu lucrarea ta. Nu poate gândi în locul tău.">
+  <meta property="og:title" content="Nu preda AI-ul, te rog.">
+  <meta property="og:description" content="AI te poate ajuta cu lucrarea ta. Nu poate gândi în locul tău.">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ro_RO">
+  <meta property="og:url" content="https://dontpastetheai.com/student/ro.html">
+  <link rel="canonical" href="https://dontpastetheai.com/student/ro.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image.png">
+  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Special+Elite&family=JetBrains+Mono:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="../styles.css">
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/student/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/student/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/student/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/student/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/student/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/student/hu.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/student/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/student/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/student/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/student/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/student/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/student/">
+  <!-- hreflang:end -->
+  <script src="../assets/translations.js" defer></script>
+  <script src="../assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>Preferi altă limbă?</span>
+        <label class="lang" aria-label="Limbă">
+          <select data-lang-select>
+            <option>RO — Română</option>
+          </select>
+        </label>
+      </div>
+      <h1>Nu preda<br>AI-ul, te rog.</h1>
+      <p class="lede">Când îți cer <em>lucrarea ta</em>, îți cer gândirea ta.
+        Nu un PDF băgat într-un chatbot și lipit înapoi la mine. <span class="marker">AI te poate ajuta să
+          lucrezi</span>. Nu poate fi el cel care face treaba.</p>
+    </header>
+
+    <section>
+      <h2>Ce s-a întâmplat</h2>
+      <p>Aveai un proiect. Ai băgat PDF-ul într-un instrument AI, i-ai cerut să scrie lucrarea, și ai predat
+        răspunsul fără să-l citești. A fost eficient. A fost și extrem de evident.</p>
+      <p>Nu ai finalizat tema. Ți-ai <strong>externalizat activitatea creierului</strong> și ți-ai pus numele pe
+        rezultat. Referințele nu se potrivesc cu argumentul, argumentul nu sună ca tine, iar uneori răspunsul e
+        greșit cu multă siguranță de sine. Știu. L-am citit.</p>
+      <p>AI a făcut treaba. AI ia nota. <em>Tu nu.</em></p>
+    </section>
+
+    <div class="shout">
+      Subcontractarea creierului tău<br>nu e <span>învățare</span>.
+    </div>
+
+    <section>
+      <h2>Fă asta în schimb</h2>
+      <ol>
+        <li>Folosește AI pentru documentare, brainstorming, explicarea unui concept dificil, sau pentru a-ți găsi o
+          direcție. Folosește-l ca instrument, nu ca substitut pentru a avea un punct de vedere.</li>
+        <li>Citește tot ce îți dă. Verifică sursele. Pune la îndoială răspunsul. Modelele pot suna sigure pe ele deși
+          sunt complet greșite, iar numele tău rămâne pe lucrare.</li>
+        <li>Fă argumentul al tău. Decide ce crezi, explică <em>de ce</em>, și folosește dovezi ca să-l susții.
+          Raționamentul tău e tema, nu numărul de paragrafe.</li>
+        <li>Editează până înțelegi fiecare propoziție. Dacă nu poți explica o afirmație fără să întrebi din nou
+          chatbot-ul, nu ești pregătit s-o predai.</li>
+        <li>Fii onest în privința instrumentului. Respectarea regulilor pentru declararea folosirii AI face parte
+          din a face treaba corect. O ciornă neșlefuită, dar cu adevărat a ta, valorează mai mult decât un răspuns
+          lustruit pe care nu l-ai înțeles niciodată.</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>Asta nu e anti-AI</h2>
+      <p>Nu îți cer să te prefaci că aceste instrumente nu există. Folosește-le ca să pui întrebări mai bune, să
+        găsești contraargumente, să testezi o idee, să îmbunătățești o ciornă, și să înveți.
+        <strong>Documentează-te. Gândește. Controlează. Argumentează. Provoacă.</strong></p>
+      <p>Dar nu preda pur și simplu proiectul și numi rezultatul munca ta. Scopul unei teme nu e să produci un obiect
+        în formă de document. E să înțelegi ceva suficient de bine încât să poți spune tu însuți.</p>
+    </section>
+
+    <section>
+      <h2>Vrei să trimiți asta cuiva?</h2>
+      <p>Dacă un student a predat o lucrare generată de AI fără s-o citească, trimite-i acest link. Poate data
+        viitoare își ține creierul în proiectul de grup.</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+          data-copy-aria="Copiază {domain} în clipboard" data-copy-path="/student/ro"
+          data-copied-text="copiat!">dontpastetheai.com/student</button></p>
+      <p class="u-center u-small u-muted u-mt-md">Click pentru a copia.</p>
+    </section>
+
+    <section>
+      <h2>Cauți originalul?</h2>
+      <p>Pagina principală e pentru oricine lipește răspunsuri de la AI fără să le citească mai întâi.</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" href="../">Înapoi la Nu lipi AI-ul</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— cu sinceritate,<br>Profesorul tău dezamăgit</div>
+      <small>văr spiritual al <a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> &amp;
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a>.<br>Scris cu
+        grijă. Corectat înainte de trimitere.</small>
+    </div>
+
+    <div class="footer">
+      <p><em>Dacă cineva ți-a trimis acest link: vrea să te gândești la asta. Citește, respiră, și scrie tu
+          următoarea propoziție.</em></p>
+      <p>Acest site e satiră (în caz că nu ai observat) — Simte-te liber să copiezi, modifici, traduci etc.
+        <a href="https://github.com/khaosdoctor/dontquotetheai" target="_blank" rel="noopener">PR-urile sunt
+          binevenite pe GitHub</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>

--- a/student/ru.html
+++ b/student/ru.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/sr-latn.html
+++ b/student/sr-latn.html
@@ -43,6 +43,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/sr.html
+++ b/student/sr.html
@@ -43,6 +43,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/tr.html
+++ b/student/tr.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/uk.html
+++ b/student/uk.html
@@ -43,6 +43,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/zh-cn.html
+++ b/student/zh-cn.html
@@ -51,6 +51,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/student/zh-tw.html
+++ b/student/zh-tw.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">

--- a/tr.html
+++ b/tr.html
@@ -40,6 +40,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/uk.html
+++ b/uk.html
@@ -43,6 +43,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/zh-cn.html
+++ b/zh-cn.html
@@ -71,6 +71,7 @@
         <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
         <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
         <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+        <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
         <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
         <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
         <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">

--- a/zh-tw.html
+++ b/zh-tw.html
@@ -43,6 +43,7 @@
   <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
   <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
   <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">


### PR DESCRIPTION
## Summary
- Adds Romanian (`ro`) for the smooth (`ro.html`), angry (`angry/ro.html`), and student (`student/ro.html`) pages
- Registers `ro` in `assets/translations.json` (both `languages` and `pages.student`)
- Adds `assets/og-image-ro.svg` for the social card (PNG will be rendered by CI on merge, per `TRANSLATING.md`)
- Adds Romanian rows to the maintainer tables in `README.md`
- Ran `scripts/sync-hreflang.mjs` and `scripts/sync-seo.mjs` locally, which is why ~60 other files each carry a 1-line diff (the new `ro` hreflang entry threaded through every existing page) plus the regenerated `sitemap.xml`

## Validation
`node scripts/check-translations.mjs` passes with **0 errors**. The only warnings are the expected missing-PNG ones for `og-image-ro.png` (SVG source exists; CI renders it on merge).

## Notes
- Tone: smooth page keeps the friendly/direct voice; angry page uses Romanian idiom ("băga pe gât" — force-feed) and a censored curse (`dr*cu'`) to match the English `f*cking` censorship pattern
- No font swap needed — Romanian is Latin-script and covered by `Special Elite`/`JetBrains Mono`

🤖 Generated with [Claude Code](https://claude.com/claude-code)