### PR TITLE
Fix typos in Polish angry version

### DIFF
--- a/angry/pl.html
+++ b/angry/pl.html
@@ -74,7 +74,7 @@
 
     <section>
       <h2>Co właśnie odwaliłeś:</h2>
-      <p>Ktoś ci zadał szczere pytanie, PRAWDZIWE pytanie. Miał nadzieje i dobre intencje. Przyszedł z nim  <em>specjalnie</em> do ciebie (cóż za zaszczyt). No i wtedy wziąłeś to pytanie, wjebałeś w prompta i przekleiłeś odpowiedź spowrotem. 
+      <p>Ktoś ci zadał szczere pytanie, PRAWDZIWE pytanie. Miał nadzieje i dobre intencje. Przyszedł z nim  <em>specjalnie</em> do ciebie (cóż za zaszczyt). No i wtedy wziąłeś to pytanie, wjebałeś w prompta i przekleiłeś odpowiedź z powrotem. 
 	  Założę się że czujesz się mega produktywny, mądry i w ogóle, co? Przykro mi to mówić, nie stałeś się ani trochę mądrzejszy, jedynie udowodniłeś że nie ma żadnej różnicy między pytaniem się ciebie, a pytaniem się AI.</p>
 
       <p><em>Zgadnij, kogo AI zastąpi najszybciej?</em></p>
@@ -126,7 +126,7 @@
         <li>Decyduj co się przyda, a co nie. Modele brzmią na przekonane, ale czasami nic się tam nie klei.
 		  Połowa tekstu jest prawdopodobnie zła, generyczna, albo jedno i drugie. I tak jest wtedy, gdy całość nie została zupełnie wyhalucynowana.
         </li>
-        <li>Napisz swoją odpowiedź. Trzy zdania <em>od ciebie</em> walą na głowę trzy paragrafy błota. Nikt nigdy nie powiedział "Ziomeeeek... Chciałbym żeby ta odpowiedź była dłuższa i bardziej robotyczna." </li>
+        <li>Napisz swoją odpowiedź. Trzy zdania <em>od ciebie</em> walą na głowę trzy akapity błota. Nikt nigdy nie powiedział "Ziomeeeek... Chciałbym żeby ta odpowiedź była dłuższa i bardziej robotyczna." </li>
         <li>Jeśli naprawdę musisz cytować model, spoko, tam też potrafi być coś dobrego! Po prostu napisz <em>dlaczego</em>. 
 		"Zapytałem się Clauda i ta część się zgadza:", no i super! Przynajmniej przeczytałeś co tam się dzieje i wciąż cię lubimy.
         </li>


### PR DESCRIPTION
## Non-translation PR

<!-- Delete the Translation section above if this doesn't apply. -->

**What changed and why:**

<!-- Brief description of the change and the motivation behind it. -->

Fixed typos in Polish translation of angry version:

- "spowrotem" is a typo
- "paragraf" is a false friend for "paragraph" 

Smooth and student didn't have those typos.

- [ ] The **Validate translations** GitHub Action passed on this PR.

---

Thanks for helping keep this site multilingual and not-quite-serious. 💛
