### PR TITLE
Make italian translation more natural

### DIFF
--- a/angry/it.html
+++ b/angry/it.html
@@ -65,7 +65,7 @@
           <select data-lang-select><option>IT — Italiano</option></select>
         </label>
       </div>
-      <h1>Basta citarmi<br>l'<span class="yell">IA</span> addosso.</h1>
+      <h1>Smetti di<br>incollarmi la cazzo di risposta<br>dell'<span class="yell">IA</span>.</h1>
       <p class="lede">Se la tua risposta inizia con <span class="marker">"Ecco cosa ha detto Claude:"</span> o sono
         direttamente <span class="marker">ottocento parole di testo di ChatGPT non rilette</span>, complimenti: hai
         appena dimostrato che il tuo cervello è un soprammobile, Darwin sarebbe fiero. <strong>Per favore, non
@@ -75,22 +75,22 @@
     <section>
       <h2>Ecco cosa hai appena fatto</h2>
       <p>Qualcuno ti ha fatto una domanda vera. Aveva il contesto e tutte le buone intenzioni. È venuto da te
-        <em>di proposito</em>. Tu hai preso la sua domanda, l'hai scaricata in un prompt e gli hai incollato
+        <em>di proposito</em>. Tu hai preso la sua domanda, l'hai sbattuta in un prompt e gli hai incollato
         indietro il risultato. Scommetto che ti sei sentito super produttivo e intelligente, eh? Beh... Mi spiace
         deluderti, non sei diventato più intelligente, hai solo dimostrato che non c'è nessuna differenza tra
         chiedere a te o chiedere all'IA.
       </p>
 
-      <p><em>Indovina chi sostituirà per primo l'IA?</em></p>
+      <p><em>Indovina chi sarà il primo a essere sostituito dall'IA?</em></p>
 
       <blockquote>
         <span class="exhibit-label">Nel caso non fosse chiarissimo, ecco cosa hai risposto:</span>
         Ottima domanda! Ci sono diversi fattori chiave da considerare quando si affronta questo tema sfaccettato
         a cui qualcuno ha dedicato tempo e cervello. Analizziamolo passo per passo, di nuovo:<br><br>
         1. <strong>Comprendere il contesto</strong> — È importante stabilire prima delle solide basi, perché è
-        letteralmente quello che hai chiesto in origine<br>
-        2. <strong>Considerazioni chiave</strong> — Quando lo valuti, dovresti tenere a mente che, son sicuro che
-        non ti era mai passato per la testa<br>
+        letteralmente quello che hai chiesto<br>
+        2. <strong>Considerazioni chiave</strong> — Quando lo valuti, dovresti tenere a mente che... Son sicuro che
+        tutto ciò che sto per dire non ti era mai passato per la testa<br>
         3. <strong>Buone pratiche</strong> — Gli esperti del settore generalmente raccomandano questa banalissima
         ricerca su Google che avresti potuto fare in 3 secondi<br><br>
 
@@ -105,7 +105,7 @@
       <p>La persona a cui stai rispondendo <strong>ha la stessa IA che hai tu</strong>. Se voleva la risposta
         generica dell'LLM, ce l'aveva in quattro secondi senza nemmeno coinvolgerti, che tra l'altro è
         <em>più facile</em>. Ha chiesto a te perché voleva <em>te</em>. La tua opinione. La tua esperienza.
-        Il tuo gusto. Tutto quello che il modello non ha.
+        Il tuo gusto. Tutto ciò che il modello non ha.
       </p>
 
       <p>Quello che gli hai mandato invece dice: <span class="marker">"Non avevo voglia di leggere la tua domanda
@@ -127,24 +127,24 @@
     <section>
       <h2>La soluzione è abbastanza semplice</h2>
       <ol>
-        <li>Puoi usare l'IA. È uno strumento della madonna. Sta li per essere usato, ma porca miseria,
-          <strong>LEGGI</strong> quello che ha detto il modello. Tutto quanto. Si, anche le liste, il codice, tutto...
+        <li>Puoi usare l'IA. È uno strumento della madonna. Esiste per essere usato, ma porca miseria,
+          <strong>LEGGI</strong> quello che ha detto il modello. Tutto quanto. Sì, anche le liste, il codice, tutto...
         </li>
-        <li>Decidi cosa è utile e cosa no. I modelli sono sicuri di se in modi che non c'entrano nulla con l'avere
-          ragione. Meta di quella roba e probabilmente sbagliata, generica, o tutte e due. Sempre che non sia
+        <li>Decidi cosa è utile e cosa no. I modelli sono sicuri di sé in modi che non c'entrano nulla con l'avere
+          ragione. Meta di quella roba è probabilmente sbagliata, generica, o tutte e due. Sempre che non sia
           un'allucinazione.</li>
         <li>Scrivi la tua risposta. Tre frasi <em>tue</em> battono tre paragrafi di sbobba, sempre. Nessuno ha
           mai detto «vorrei che quella risposta fosse stata più lunga e più robotica».</li>
-        <li>Se devi davvero citare il modello, ok, ci sono cose buone li dentro! Spiega <em>perche</em>.
-          "Ho chiesto a Claude e questa parte torna davvero:" perfetto! Almeno hai letto cosa e successo.</li>
+        <li>Se devi proprio citare il modello, OK, alcune risposte sono buone! Però spiega <em>perché</em>.
+          "Ho chiesto a Claude e questa parte è effettivamente corretta:" perfetto! Almeno hai letto cosa ti ha detto.</li>
         <li>Se non hai niente da aggiungere, <strong>non dire niente</strong>. Il silenzio
-          e un contributo. O di' "non ho niente da aggiungere". Risparmierai tempo a tutti.</li>
+          è un contributo. O di' "non ho niente da aggiungere". Risparmierai tempo a tutti.</li>
       </ol>
     </section>
 
     <section>
-      <h2>«Ma io voglio aiutare anch'io!»</h2>
-      <p>No, non vuoi. Stai cercando di <em>sembrare</em> utile senza fare il lavoro di esserlo davvero. C'è una
+      <h2>«Ma io voglio aiutare!»</h2>
+      <p>No, non vuoi. Stai cercando di <em>sembrare</em> utile senza fare il lavoro per esserlo davvero. C'è una
         differenza.</p>
       <p>Aiutare significa <strong>leggere</strong> con attenzione, <strong>pensare</strong>, e
         <strong>rispondere</strong> con qualcosa che solo tu avresti potuto dire, o almeno rielaborare. Incollare roba da un'IA dice
@@ -155,9 +155,9 @@
 
     <section>
       <h2>Non è anti-IA. Calma.</h2>
-      <p>Usa gli strumenti. Usali tutti i giorni. Usali per fare bozze più veloci, essere piu creativo, imparare di piu, sbloccarti. Benissimo. È proprio quello il punto. <strong>L'output è un punto di
-          partenza, non una consegna.</strong> Trattalo come la prima bozza di uno stagista, perché è esattamente
-        quello. Editalo. Taglialo. Dissenti. Rendilo tuo, oppure non mandarlo.</p>
+      <p>Usa gli strumenti. Usali tutti i giorni. Usali per fare bozze più rapidamente, essere piu creativo, imparare di più, sbloccarti. Benissimo. È proprio quello il punto. <strong>L'output è un punto di
+          partenza, non un prodotto finale.</strong> Trattalo come la prima bozza di uno stagista, perché è esattamente
+        quello. Modificalo. Taglialo. Dissenti. Rendilo tuo, oppure non mandarlo.</p>
     </section>
 
     <section>
@@ -172,7 +172,7 @@
 
     <section>
       <h2>Troppo?</h2>
-      <p>Tranquillo. Se preferisci mandare la versione da ufficio? Ce l'abbiamo anche quella:</p>
+      <p>Tranquillo. Preferisci mandare la versione da ufficio? Abbiamo anche quella:</p>
       <p class="u-center u-mt-lg"><a class="cta-calm" href="../it.html">← Sono schiavo del capitalismo</a></p>
     </section>
 
@@ -186,7 +186,7 @@
     <div class="footer">
       <p><em>Se qualcuno ti ha mandato questo link: non <a href="https://www.youtube.com/watch?v=xzpndHtdl9A"
             target="_blank" rel="noopener">te la prendere</a> con lui. Vuole il tuo bene. Leggi, respira, e
-          scrivi la prossima risposta tu.</em></p>
+          la prossima risposta scrivila tu.</em></p>
       <p>Satira (se non l'avevi notato). Liberi di copiare, modificare e tradurre — <a
           href="https://github.com/khaosdoctor/dontpastetheai" target="_blank" rel="noopener">PR ben accette su
           GitHub</a>.</p>

--- a/it.html
+++ b/it.html
@@ -67,7 +67,7 @@
       </div>
       <h1>Non incollare<br>l'<span class="yell">IA</span>, per favore.</h1>
       <p class="lede">Quando qualcuno ti chiede qualcosa, vuole <em>la tua</em> risposta.
-        Non un muro di <span class="marker">ChatGPT copiato senza rileggere</span>. Una risposta breve tua
+        Non un muro di testo di <span class="marker">ChatGPT copiato senza rileggere</span>. Una tua risposta breve
         batte una lunga del modello, sempre, anche se il robot ha ragione.</p>
     </header>
 
@@ -92,11 +92,11 @@
           sono copiate, almeno le hai lette.
         </li>
         <li>Se un pezzo della risposta del modello è davvero utile, citalo e di' <em>perché</em>.
-          <span class="marker"><em>"Ho controllato con Claude e questa parte torna:"</em></span> funziona
+          <span class="marker"><em>"Ho controllato con Claude e questa parte torna:"</em></span> va
           benissimo.
         </li>
-        <li>Se non hai niente da aggiungere, va benissimo dirlo. <span class="marker"><em>"Non ho un'opinione
-              forte qui"</em></span> è una risposta vera, e utile.
+        <li>Se non hai niente da aggiungere, è sufficiente dirlo. <span class="marker"><em>"Non ho un'opinione
+              forte in proposito"</em></span> è una risposta vera, e utile.
         </li>
       </ol>
     </section>
@@ -133,8 +133,8 @@
     </div>
 
     <div class="footer">
-      <p><em>Se qualcuno ti ha mandato questo link: vuole che ci rifletti. Leggi, respira, e scrivi la prossima
-          risposta tu.</em></p>
+      <p><em>Se qualcuno ti ha mandato questo link: vuole che tu ci rifletta. Leggi, respira, e la prossima
+          risposta scrivila tu.</em></p>
       <p>Satira (se ancora non l'avevi capito). Liberi di copiare, modificare e tradurre — <a
           href="https://github.com/khaosdoctor/dontquotetheai" target="_blank" rel="noopener">PR ben accette
           su GitHub</a>.</p>


### PR DESCRIPTION
Avoid some constructs borrowed from English, add accents where missing.

Also add a swear word to the angry version title to match the source.

---

## Translation PR

**Language code (BCP 47, lowercase):** `it`

Please confirm:

- [x] I translated **both** the smooth version (`<code>.html`) **and** the angry version (`angry/<code>.html`).
- [x] I added an entry for my language to `assets/translations.json` (with `code`, `hreflang`, `label`, `file`).
- [x] I added a `<link rel="alternate" hreflang="...">` tag for my language to **every other HTML file** (smooth → smooth URLs, angry → angry URLs). See `TRANSLATING.md` for the full list.
- [x] My files have the correct `<html lang="...">`, `<link rel="canonical">`, `<meta property="og:url">`, and `<meta name="twitter:image">` pointing at `https://dontpastetheai.com/...`.
- [x] I created `assets/og-image-<code>.svg` (and `.png` if I could render it — otherwise SVG only is fine, just call it out below).
- [x] I updated the no-JS fallback `<option>` inside `<select data-lang-select>` so my language appears with its label.
- [x] The **Validate translations** GitHub Action passed on this PR.
