### PR TITLE
Copy button does not copy with language

### DIFF
--- a/de.html
+++ b/de.html
@@ -106,7 +106,8 @@
       <p>Wenn dir gerade jemand eine Textwand aus dem Chatbot in die DMs, in Slack oder ins Code-Review
         gekippt hat: Schick ihr einfach diesen Link. Ganz ohne Vortrag.</p>
       <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
-          data-copy-aria="{domain} in die Zwischenablage kopieren" data-copied-text="kopiert!">dontpastetheai.com</button></p>
+          data-copy-aria="{domain} in die Zwischenablage kopieren" data-copy-path="/de"
+          data-copied-text="kopiert!">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">Klicken zum Kopieren. Den Rest versteht die Person schon.</p>
     </section>
 

--- a/es.html
+++ b/es.html
@@ -98,7 +98,7 @@
     <section>
       <h2>¿Quieres enviarle este sitio a alguien?</h2>
       <p>Si alguien ya te envió un párrafo enorme en un mensaje, <abbr title="Pull Request">PR</abbr> o correo, envíale este link. No tienes que explicarle más detalles.</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/es"
           data-copy-aria="Copiar {domain}" data-copied-text="listo!">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">Haz click para copiar. Van a entender el mensaje.</p>
     </section>

--- a/fa.html
+++ b/fa.html
@@ -169,6 +169,7 @@
             id="copyBtn"
             type="button"
             class="url-tag-big"
+            data-copy-path="fa"
             data-copy-aria="{domain} کپی شد"
             data-copied-text="کپی شد!"
           >

--- a/fr.html
+++ b/fr.html
@@ -109,7 +109,7 @@
       <h2>Tu veux envoyer ceci à quelqu'un?</h2>
       <p>Si quelqu'un vient de déverser un mur de texte de modèle dans tes DM, Slack ou revue de code, tu peux lui
         envoyer ce lien. Pas besoin de lui faire la leçon.</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/fr"
           data-copy-aria="Copier {domain} dans le presse-papier" data-copied-text="copié!">dontpastetheai.com</button>
       </p>
       <p class="u-center u-small u-muted u-mt-md">Clique pour copier. Il comprendra.</p>

--- a/hu.html
+++ b/hu.html
@@ -109,7 +109,7 @@
       <h2>Elküldenéd ezt valakinek?</h2>
       <p>Ha valaki egy rakás AI generált szöveget küldött neked üzenetben, Slacken, vagy PR reviewban, küldd el nekik
         ezt a linket. Nem kell kioktatni.</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/hu"
           data-copy-aria="Másold a {domain} linket a vágólapra" data-copied-text="copied!">dontpastetheai.com</button>
       </p>
       <p class="u-center u-small u-muted u-mt-md">Kattints a másoláshoz. Átmegy majd az üzenet.</p>

--- a/hy.html
+++ b/hy.html
@@ -105,7 +105,7 @@
     <section>
       <h2>Ուզո՞ւմ ես սա մեկին ուղարկել</h2>
       <p>Եթե մեկը հենց նոր LLM տեքստի մի խուրձ է ուղարկել քո անձնական նամակների, Slack-ի կամ կոդի ստուգման մեջ, կարող ես նրան ուղարկել այս հղումը։</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/hy"
           data-copy-aria="Պատճենել {domain}-ը" data-copied-text="Պատճենվեց">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">Սեղմիր պատճենելու համար։</p>
     </section>

--- a/id.html
+++ b/id.html
@@ -101,7 +101,7 @@
       <h2>Mau kirimin ini ke orang?</h2>
       <p>Kalau ada yang baru aja ngirim wall of text dari AI di DM, Slack, atau PR review kamu, kirimin aja
         link ini. Nggak perlu ceramah.</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/id"
           data-copy-aria="Salin {domain} ke clipboard" data-copied-text="tersalin!">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">Klik buat nyalin. Mereka pasti ngerti.</p>
     </section>

--- a/it.html
+++ b/it.html
@@ -105,7 +105,7 @@
       <h2>Vuoi mandarlo a qualcuno?</h2>
       <p>Se qualcuno ti ha appena scaricato un muro di output del modello in DM, su Slack o in una code review,
         puoi mandargli questo link. Senza fare la predica.</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/it"
           data-copy-aria="Copia {domain} negli appunti" data-copied-text="copiato!">dontpastetheai.com</button>
       </p>
       <p class="u-center u-small u-muted u-mt-md">Clicca per copiare. Il messaggio arriverà.</p>

--- a/ja.html
+++ b/ja.html
@@ -108,7 +108,7 @@
     <section>
       <h2>誰かに送りたいですか？</h2>
       <p>誰かがずらずらとLLMの文章をDMや、Slackや、コードレビューで投げてきたら、こちらのリンクを送れます。</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/ja"
           data-copy-aria="クリップボードに{domain}をコピー" data-copied-text="コピーしました！">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">クリックしてコピー。</p>
     </section>

--- a/ko.html
+++ b/ko.html
@@ -96,7 +96,8 @@
     <section>
       <h2>누군가에게 이 페이지를 보내고 싶나요?</h2>
       <p>누군가 DM, Slack 또는 코드 리뷰에 LLM이 쓴 글을 한가득 올렸다면 이 링크를 보내세요.</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-aria="{domain}을(를) 클립보드에 복사" data-copied-text="복사했습니다!">dontpastetheai.com</button></p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+        data-copy-path="/ko" data-copy-aria="{domain}을(를) 클립보드에 복사" data-copied-text="복사했습니다!">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">클릭해서 복사하세요.</p>
     </section>
 

--- a/ne.html
+++ b/ne.html
@@ -109,7 +109,7 @@
       <h2>कसैलाई पठाउन मन छ?</h2>
       <p>कसैले भर्खरै तपाईंको डीएम, स्ल्याक वा पीआर रिभ्युमा मोडेलको आउटपुटको पर्खाल खसालिदियो भने
         उसलाई यो लिङ्क पठाइदिनुहोस्। भाषण दिनु पर्दैन।</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/ne"
           data-copy-aria="{domain} लाई क्लिपबोर्डमा कपी गर्नुहोस्" data-copied-text="कपी भयो!">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">कपी गर्न क्लिक गर्नुहोस्। उसले बुझिहाल्छ।</p>
     </section>

--- a/pl.html
+++ b/pl.html
@@ -77,7 +77,7 @@
       <p>Ktoś zadał ci szczere pytanie. Wrzuciłeś je w czata, skopiowałeś odpowiedź i mu odesłałeś.
         Miało być szybko. Miało być pożytecznie. Nie było.</p>
       <p>Może nie widać tego na pierwszy rzut oka, ale osoba po drugiej stronie <strong>ma te same narzędzia, co ty</strong>. Jeżeli ona
-        chce generycznej odpowiedzi, to by ją miała w kilka sekund. Ta osoba zapytała się <em>ciebie</em> bo chciała 
+        chce generycznej odpowiedzi, to by ją miała w kilka sekund. Ta osoba zapytała się <em>ciebie</em> bo chciała
         zobaczyć co ty myślisz... Twojego kontekstu, twojego gustu, twojej oceny.</p>
 
       <p>Świat jest pełen ludzi, którzy nie chcą czytać ani myśleć. Nie bądź jednym z nich.</p>
@@ -88,7 +88,7 @@
       <ol>
         <li>Możesz użyć AI. Serio! To świetne narzędzie do szkicowania. Po prostu <strong>przeczytaj, co dostałeś</strong>, a potem napisz swoją wersję lub doszlifuj tekst. Nie bądź pośrednikiem między czatem,
           a odpowiedzią.</li>
-        <li>Weź część, która faktycznie odpowiedziała na pytanie i zignoruj resztę. Trzy zdania to wszystko czego potrzeba, a nawet jeśli są skopiowane, 
+        <li>Weź część, która faktycznie odpowiedziała na pytanie i zignoruj resztę. Trzy zdania to wszystko czego potrzeba, a nawet jeśli są skopiowane,
 		to przynajmniej je przeczytałeś.</li>
         <li>Gdy jakaś część odpowiedzi z modelu jest naprawdę przydatna, zacytuj ją i wyjaśnij <em>dlaczego</em>.
           <span class="marker"><em>"Zapytałem się Clauda i ten kawałek ma sens:"</em></span>.
@@ -102,7 +102,7 @@
       <h2>Chcesz to komuś wysłać?</h2>
       <p>Jeżeli ktoś właśnie wrzucił w DM-ach, Slacku lub code review ścianę tekstu przeklejoną z LLMa, możesz
         podesłać im ten link.</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/pl"
           data-copy-aria="Skopiuj {domain} do schowka" data-copied-text="skopiowano!">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">Kliknij żeby skopiować.</p>
     </section>
@@ -124,12 +124,12 @@
     <div class="signature">
       <div class="name">— z... Miłością? <br>Wszyscy</div>
       <small>pokrewna dusza strony <a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> &amp;
-        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a>.<br>napisane przez 
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a>.<br>napisane przez
 		jakiegoś losowego gościa (<a href="https://github.com/khaosdoctor/dontquotetheai/issues/31" target="_blank" rel="noopener">wierz mi lub nie</a>). Tak jak kiedyś.</small>
     </div>
 
     <div class="footer">
-      <p><em>Jeżeli ktoś ci wysłał ten link: chce żebyś o tym pomyślał. Przeczytaj, weź wdech i następną odpowiedź 
+      <p><em>Jeżeli ktoś ci wysłał ten link: chce żebyś o tym pomyślał. Przeczytaj, weź wdech i następną odpowiedź
 	  napisz samemu.</em></p>
       <p>Ta strona jest satyrą (jeśli jeszcze nie zauważyłeś) — Jak chcesz to sobie skopiuj, zmień, przetłumacz, itd.
         <a href="https://github.com/khaosdoctor/dontquotetheai" target="_blank" rel="noopener">PRy mile widziane na GitHubie</a>.

--- a/pt-br.html
+++ b/pt-br.html
@@ -106,7 +106,7 @@
       <h2>Quer mandar isso pra alguém?</h2>
       <p>Se alguém acabou de cometer uma parede de texto de LLM no seu DM, Slack ou code review, você
         pode mandar esse link.</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/pt-br"
           data-copy-aria="Copiar {domain} para clipboard" data-copied-text="copiado!">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">Clique pra copiar.</p>
     </section>

--- a/ro.html
+++ b/ro.html
@@ -106,7 +106,7 @@
       <h2>Vrei să trimiți asta cuiva?</h2>
       <p>Dacă cineva tocmai a dat drumul la un talmeș-balmeș de text generat de un LLM în DM-uri, pe Slack sau într-un code
         review, îi poți trimite acest link.</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/ro"
           data-copy-aria="Copiază {domain} în clipboard" data-copied-text="copiat!">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">Click pentru a copia.</p>
     </section>

--- a/ru.html
+++ b/ru.html
@@ -101,7 +101,7 @@
       <h2>Хочешь это кому-то отправить?</h2>
       <p>Если кто-то только что скинул тебе простыню с ответом ЛЛМки в личку, в Slack или в ревью пулл-реквеста — просто
         отправь ему в ответе эту ссылку. Без нотаций.</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/ru"
           data-copy-aria="Скопировать {domain} в буфер обмена" data-copied-text="скопировано!">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">Нажми, чтобы скопировать.</p>
     </section>

--- a/sr-latn.html
+++ b/sr-latn.html
@@ -106,7 +106,7 @@
       <h2>Hoćeš da ovo pošalješ nekome?</h2>
       <p>Ako ti je neko upravo ubacio zid teksta od modela u poruke, Slack ili pregled koda, možeš da mu pošalješ
         ovaj link. Bez opaske.</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/sr-latn"
           data-copy-aria="Kopiraj {domain} u klipbord" data-copied-text="kopirano!">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">Klikni da kopiraš.</p>
     </section>

--- a/sr.html
+++ b/sr.html
@@ -106,7 +106,7 @@
       <h2>Хоћеш да ово пошаљеш некоме?</h2>
       <p>Ако ти је неко управо убацио зид текста од модела у поруке, Slack или преглед кода, можеш да му пошаљеш
         овај линк. Без опаске.</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/sr"
           data-copy-aria="Копирај {domain} у клипборд" data-copied-text="копирано!">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">Кликни да копираш.</p>
     </section>

--- a/tr.html
+++ b/tr.html
@@ -102,7 +102,7 @@
       <h2>Bunu birine göndermek ister misin?</h2>
       <p>Biri özel mesajlarına, Slack'e ya da PR incelemene modelden çıkma koca bir metin bıraktıysa ona bu bağlantıyı
         gönderebilirsin. Ders vermene gerek yok.</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/tr"
           data-copy-aria="{domain} adresini panoya kopyala" data-copied-text="kopyalandı!">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">Kopyalamak için tıkla. Mesajı anlayacaktır.</p>
     </section>

--- a/uk.html
+++ b/uk.html
@@ -106,7 +106,7 @@
       <p>Якщо тобі щойно вивалили простирадло модельного тексту в особисті повідомлення, у Slack чи в код
         рев'ю — надішли їм це посилання. Без зайвих повчань.</p>
       <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
-          data-copy-aria="Скопіювати {domain} у буфер обміну"
+          data-copy-aria="Скопіювати {domain} у буфер обміну" data-copy-path="/uk"
           data-copied-text="скопійовано!">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">Натисни, щоб скопіювати.</p>
     </section>

--- a/zh-cn.html
+++ b/zh-cn.html
@@ -150,6 +150,7 @@
                         id="copyBtn"
                         type="button"
                         class="url-tag-big"
+                        data-copy-path="/zh-cn"
                         data-copy-aria="将 {domain} 复制到剪贴板"
                         data-copied-text="已复制！"
                     >

--- a/zh-tw.html
+++ b/zh-tw.html
@@ -92,7 +92,7 @@
     <section>
       <h2>想把這個網頁傳給某人嗎？</h2>
       <p>如果有人剛剛在私訊、Slack 或 PR review 裡對你丟了一大坨 AI 產生的廢話，你可以直接把這個連結丟給他。省去說教的力氣。</p>
-      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big" data-copy-path="/zh-tw"
           data-copy-aria="複製 {domain} 到剪貼簿" data-copied-text="已複製！">dontpastetheai.com</button></p>
       <p class="u-center u-small u-muted u-mt-md">點擊即可複製。懂的人就懂。</p>
     </section>


### PR DESCRIPTION
## Non-translation PR

At root pages, whenever user copies using the button, it only copies the domain, which will lead the clicked link to show only english version or the previous language that user has selected before.

Kept the same pattern of angry and student with `data-copy-path` tag, so the button always displays "{domain}/{lang}" _(except for english/index version)_

---

- [x] The **Validate translations** GitHub Action passed on this PR.