### PR TITLE
feat: add Hindi (hi) and Punjabi (pa) translations

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -41,6 +41,7 @@ jobs:
           curl -fsSL "https://cdn.jsdelivr.net/fontsource/fonts/noto-sans-tc@latest/chinese-traditional-400-normal.ttf" -o ~/.local/share/fonts/noto-sans-tc.ttf || true
           curl -fsSL "https://cdn.jsdelivr.net/fontsource/fonts/noto-sans-devanagari@latest/devanagari-400-normal.ttf" -o ~/.local/share/fonts/noto-sans-devanagari.ttf || true
           curl -fsSL "https://cdn.jsdelivr.net/fontsource/fonts/noto-serif-armenian@latest/armenian-400-normal.ttf" -o ~/.local/share/fonts/noto-serif-armenian.ttf || true
+          curl -fsSL "https://cdn.jsdelivr.net/fontsource/fonts/noto-sans-gurmukhi@latest/gurmukhi-400-normal.ttf" -o ~/.local/share/fonts/noto-sans-gurmukhi.ttf || true
           fc-cache -f
 
       - name: Sort translations.json alphabetically

--- a/angry/hi.html
+++ b/angry/hi.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="hi">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>मेरे मुँह पर AI चिपकाना बंद करो।</title>
+  <meta name="description" content="अगर तुम्हारा जवाब LLM की बकवास का ढेर है, तो दिक्क़त तुम हो।">
+  <meta property="og:title" content="AI मत चिपकाओ">
+  <meta property="og:description" content="अगर तुम्हारा जवाब LLM की बकवास का ढेर है, तो दिक्क़त तुम हो।">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-hi.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="hi_IN">
+  <meta property="og:url" content="https://dontpastetheai.com/angry/hi.html">
+  <link rel="canonical" href="https://dontpastetheai.com/angry/hi.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image-hi.png">
+  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Noto+Sans+Devanagari:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="../styles.css">
+  <style>
+    :root {
+      --font-type: "Kalam", cursive;
+      --font-mono: "Noto Sans Devanagari", sans-serif;
+    }
+  </style>
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/angry/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/angry/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/angry/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/angry/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/angry/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/angry/hu.html">
+  <link rel="alternate" hreflang="hy" href="https://dontpastetheai.com/angry/hy.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/angry/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/angry/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/angry/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/angry/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/angry/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/angry/">
+  <!-- hreflang:end -->
+  <script src="../assets/translations.js" defer></script>
+  <script src="../assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>अपनी ही भाषा में सुनो:</span>
+        <label class="lang" aria-label="भाषा">
+          <select data-lang-select>
+            <option>HI — हिन्दी</option>
+          </select>
+        </label>
+      </div>
+      <h1>ये स*ली <span class="yell">AI</span> वाली<br>बकवास चिपकाना बंद करो।</h1>
+      <p class="lede">अगर तुम्हारा जवाब <span class="marker">"देखो Claude ने क्या कहा:"</span> से शुरू होता है, या तुम
+        <span class="marker">ChatGPT से निकले आठ सौ शब्द</span> ठोक देते हो, तो बधाई हो: तुमने अभी-अभी साबित कर दिया कि
+        तुम्हारा दिमाग़ सिर्फ़ सजावट के लिए है, डार्विन को गर्व होता। <strong>प्लीज़ बच्चे मत पैदा करना</strong>।
+      </p>
+    </header>
+
+    <section>
+      <h2>तुमने अभी-अभी किया क्या:</h2>
+      <p>किसी ने तुमसे एक सच्चा सवाल पूछा, बिल्कुल असली वाला। उसके पास पूरा संदर्भ था और नीयत भी साफ़ थी। वो
+        <em>ख़ास तौर पर</em> तुम्हारे पास आया (कितनी बड़ी इज़्ज़त है)। फिर तुमने वो सवाल उठाया, प्रॉम्प्ट बॉक्स में
+        डाल दिया, और नतीजा वापस चिपका दिया। लगा होगा कि आज तो बड़े प्रोडक्टिव और होशियार हो गए... माफ़ करना, तुम ज़रा
+        भी होशियार नहीं हुए। तुमने बस ये साबित किया कि तुमसे पूछने और AI से पूछने में कोई फ़र्क़ ही नहीं है।
+      </p>
+
+      <p><em>अंदाज़ा लगाओ, AI सबसे पहले किसे रिप्लेस करेगा?</em></p>
+
+      <blockquote>
+        <span class="exhibit-label">अगर बात साफ़ न हुई हो, तो ये रहा तुम्हारा जवाब:</span>
+        बहुत बढ़िया सवाल! इस सूक्ष्म विषय पर विचार करते समय कई महत्वपूर्ण पहलुओं को ध्यान में रखना ज़रूरी है, जिन पर
+        किसी ने सच में सोचने की तकलीफ़ उठाई थी। चलिए इसे चरण-दर-चरण समझते हैं, फिर से:<br><br>
+        1. <strong>संदर्भ को समझना</strong> — सबसे पहले एक मज़बूत आधार बनाना ज़रूरी है, क्योंकि तुमने शुरू में यही तो
+        पूछा था<br>
+        2. <strong>मुख्य बातें</strong> — इसका मूल्यांकन करते समय ध्यान रखें कि... मुझे पूरा यक़ीन है कि जो मैं अब
+        कहने जा रहा हूँ, वो तुम्हारे दिमाग़ में कभी नहीं आया होगा<br>
+        3. <strong>सर्वोत्तम तरीक़े</strong> — विशेषज्ञ आमतौर पर यही Google सर्च करने की सलाह देते हैं, जो तुम 3 सेकंड
+        में कर सकते थे<br><br>
+
+        निष्कर्ष यह है कि उत्तर अंततः आपकी विशिष्ट परिस्थिति पर निर्भर करता है। आशा है इससे मदद मिलेगी, चैंपियन! अगर
+        आप चाहें तो मैं इनमें से किसी भी बिंदु पर और विस्तार से बता सकता हूँ।
+
+        <em>वाह... कितना ज्ञान, नया बुद्ध हमारे बीच है। इस मोती के लिए शुक्रिया, जो मुझे ख़ुद ही मिल जाता।</em>
+      </blockquote>
+    </section>
+
+    <section>
+      <h2>ये सरासर बेइज़्ज़ती है</h2>
+      <p>जिसे तुमने जवाब भेजा है, <strong>उसके पास भी वही AI है जो तुम्हारे पास है</strong>। उसे अगर वही घिसा-पिटा LLM
+        जवाब चाहिए होता, तो तुमसे बात किए बिना सेकंडों में मिल जाता, जो वैसे भी <em>ज़्यादा आसान</em> है। पर उसने
+        तुमसे पूछा, क्योंकि उसे <em>तुम</em> चाहिए थे। तुम्हारी राय। तुम्हारा तजुर्बा। तुम्हारी समझ। वो सब, जो किसी
+        मॉडल के पास नहीं है।
+      </p>
+
+      <p>तुमने बदले में जो भेजा उसका मतलब था: <span class="marker">"मेरे पास तुम्हारा सवाल ढंग से पढ़ने और सच में जवाब
+          देने का सब्र नहीं था, तो ये लो, रोबोट ने यही कहा"</span>। ये बातचीत में <strong>ईमेल फ़ॉरवर्ड करने</strong>
+        जैसा है।
+      </p>
+
+      <p>तुम किसी से ज़्यादा होशियार नहीं हो। तुम बस अपनी इज़्ज़त रियल टाइम में गँवा रहे हो, और ऐसी कि वापस पाना
+        मुश्किल होगा। तुमने अपनी राय बेचकर एक फ़ॉर्च्यून कुकी वाली लाइन ख़रीद ली और आगे बढ़ गए।
+      </p>
+
+      <p>अगर तुम यही करते रहे, तो <em>कोई तुमसे कुछ पूछेगा ही क्यों?</em></p>
+    </section>
+
+    <div class="shout">
+      मॉडल चिपकाना<br><span>सोचना</span> नहीं है।
+    </div>
+
+    <section>
+      <h2>इलाज बहुत आसान है</h2>
+      <ol>
+        <li>AI इस्तेमाल करो। अच्छा औज़ार है। इस्तेमाल के लिए ही बना है, पर हम सबकी अक़्ल की ख़ैर के लिए, मॉडल ने जो
+          कहा है उसे <strong>पढ़ो</strong>। पूरा। हाँ, लिस्ट भी, कोड भी, सब कुछ...
+        </li>
+        <li>तय करो क्या काम का है और क्या नहीं। मॉडल इतने आत्मविश्वास से बोलते हैं कि उसका सही होने से कोई लेना-देना
+          ही नहीं। आधा तो शायद ग़लत होगा, घिसा-पिटा होगा, या दोनों। और ये तब है जब वो सीधे-सीधे हैलुसिनेशन न हो।
+        </li>
+        <li>अपना जवाब ख़ुद लिखो। <em>तुम्हारे</em> तीन वाक्य हर बार तीन पैराग्राफ़ की बकवास से भारी पड़ेंगे। आज तक
+          किसी ने नहीं कहा कि "वाह भाई... काश ये जवाब और लंबा होता, और थोड़ा और रोबोट जैसा"।</li>
+        <li>अगर सच में मॉडल को कोट करना ज़रूरी है, तो ठीक है, उसमें अच्छी चीज़ें भी होती हैं! बस इतना बता दो कि
+          <em>क्यों</em>। "मैंने Claude से पूछा और ये हिस्सा वाक़ई सही बैठता है:", ये चलेगा! कम से कम तुमने पढ़ा तो,
+          हमें अब भी तुम पसंद हो
+        </li>
+        <li>अगर कहने को कुछ नहीं है, तो <strong>कुछ मत कहो</strong>। चुप्पी भी एक योगदान है। या कह दो "मेरे पास जोड़ने
+          को कुछ नहीं है"। सबका वक़्त बचेगा।</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>"पर मैं तो मदद करना चाहता था!"</h2>
+      <p>नहीं, तुम नहीं चाहते थे। तुम मदद करने की मेहनत किए बिना मददगार <em>दिखना</em> चाहते थे। दोनों में फ़र्क़ है।
+      </p>
+      <p>मदद करना यानी ध्यान से <strong>पढ़ना</strong>, <strong>सोचना</strong>, और ऐसा कुछ <strong>जवाब देना</strong>
+        जो सिर्फ़ तुम कह सकते थे, या कम से कम जिसे तुमने सँवारा हो। AI का माल चिपकाना सामने वाले से कहता है कि उसका
+        सवाल तुम्हारे वक़्त के लायक़ नहीं था, बस एक चैटबॉट के लायक़ था। तुम्हें कैसा लगता?
+      </p>
+    </section>
+
+    <section>
+      <h2>ये साइट AI-विरोधी नहीं है।</h2>
+      <p>टूल इस्तेमाल करो। रोज़ करो। तेज़ी से ड्राफ़्ट बनाने के लिए, ज़्यादा क्रिएटिव होने के लिए, ज़्यादा सीखने के
+        लिए, अटकने पर आगे बढ़ने के लिए। बढ़िया। वो इसीलिए बने हैं। <strong>उनका आउटपुट शुरुआत है, डिलीवरेबल
+          नहीं।</strong> उसे किसी जूनियर इंटर्न के पहले ड्राफ़्ट की तरह लो, क्योंकि वो ठीक वही है। एडिट करो। काटो।
+        उससे असहमत हो। उसे अपना बनाओ, वरना मत भेजो।
+      </p>
+    </section>
+
+    <section>
+      <h2>इसका इस्तेमाल कैसे करें?</h2>
+      <p>अगली बार कोई तुम्हारे DM में, तुम्हारे Slack में, तुम्हारे कोड रिव्यू में, सच कहें तो कहीं भी, बिना पढ़े LLM
+        टेक्स्ट की दीवार ठोक दे, तो उसे ये भेजो:</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" data-copy-path="/angry/hi" type="button" class="url-tag-big"
+          data-copy-aria="{domain} को क्लिपबोर्ड पर कॉपी करें" data-copied-text="कॉपी हो गया!">dontpastetheai.com</button></p>
+      <p class="u-center u-small u-muted u-mt-md">कॉपी करने के लिए क्लिक करो।</p>
+    </section>
+
+    <section>
+      <h2>ज़्यादा भारी पड़ गया?</h2>
+      <p>कोई बात नहीं। दफ़्तर में चलने लायक़ वर्शन भेजना है? वो भी हाज़िर है:</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" data-variant-toggle href="../">← मैं पूँजीवाद का ग़ुलाम
+          हूँ</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— सादर,<br> शायद हम सब</div>
+      <small><a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> और
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a> का आध्यात्मिक चचेरा
+        भाई।<br>ये पेज <a href="https://github.com/khaosdoctor/dontquotetheai/issues/31" target="_blank"
+          rel="noopener">किसी रैंडम आदमी</a> ने लिखा है (हैरानी की बात है ना?)। और सच में प्रूफ़रीड भी किया गया है।
+      </small>
+    </div>
+
+    <div class="footer">
+      <p><em>अगर किसी ने तुम्हें ये लिंक भेजा है, तो उस पर <a href="https://www.youtube.com/watch?v=xzpndHtdl9A"
+            target="_blank" rel="noopener">ग़ुस्सा</a> मत होना। उसने अच्छी नीयत से भेजा है। पढ़ो, साँस लो, और अगला
+          जवाब ख़ुद लिखो।</em></p>
+      <p>व्यंग्य है (अगर छूट गया हो तो)। शेयर करने, बदलने और अनुवाद करने के लिए आज़ाद —
+        <a href="https://github.com/khaosdoctor/dontpastetheai" target="_blank" rel="noopener">GitHub पर PR का स्वागत
+          है</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>

--- a/angry/pa.html
+++ b/angry/pa.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="pa">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ਮੇਰੇ ਮੂੰਹ 'ਤੇ AI ਚਿਪਕਾਉਣਾ ਬੰਦ ਕਰ।</title>
+  <meta name="description" content="ਜੇ ਤੇਰਾ ਜਵਾਬ LLM ਦੀ ਬਕਵਾਸ ਦਾ ਢੇਰ ਹੈ, ਤਾਂ ਮਸਲਾ ਤੂੰ ਹੈਂ।">
+  <meta property="og:title" content="AI ਨਾ ਚਿਪਕਾ">
+  <meta property="og:description" content="ਜੇ ਤੇਰਾ ਜਵਾਬ LLM ਦੀ ਬਕਵਾਸ ਦਾ ਢੇਰ ਹੈ, ਤਾਂ ਮਸਲਾ ਤੂੰ ਹੈਂ।">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-pa.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="pa_IN">
+  <meta property="og:url" content="https://dontpastetheai.com/angry/pa.html">
+  <link rel="canonical" href="https://dontpastetheai.com/angry/pa.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image-pa.png">
+  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Noto+Serif+Gurmukhi:wght@400;700&family=Noto+Sans+Gurmukhi:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="../styles.css">
+  <style>
+    :root {
+      --font-type: "Noto Serif Gurmukhi", serif;
+      --font-mono: "Noto Sans Gurmukhi", sans-serif;
+    }
+  </style>
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/angry/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/angry/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/angry/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/angry/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/angry/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/angry/hu.html">
+  <link rel="alternate" hreflang="hy" href="https://dontpastetheai.com/angry/hy.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/angry/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/angry/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/angry/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/angry/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/angry/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/angry/">
+  <!-- hreflang:end -->
+  <script src="../assets/translations.js" defer></script>
+  <script src="../assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>ਆਪਣੀ ਹੀ ਬੋਲੀ ਵਿੱਚ ਸੁਣ ਲੈ:</span>
+        <label class="lang" aria-label="ਭਾਸ਼ਾ">
+          <select data-lang-select>
+            <option>PA — ਪੰਜਾਬੀ</option>
+          </select>
+        </label>
+      </div>
+      <h1>ਇਹ ਸ*ਲੀ <span class="yell">AI</span> ਵਾਲੀ<br>ਬਕਵਾਸ ਚਿਪਕਾਉਣੀ ਬੰਦ ਕਰ।</h1>
+      <p class="lede">ਜੇ ਤੇਰਾ ਜਵਾਬ <span class="marker">"ਦੇਖ Claude ਨੇ ਕੀ ਕਿਹਾ:"</span> ਤੋਂ ਸ਼ੁਰੂ ਹੁੰਦਾ ਹੈ, ਜਾਂ ਤੂੰ
+        <span class="marker">ChatGPT ਤੋਂ ਨਿਕਲੇ ਅੱਠ ਸੌ ਸ਼ਬਦ</span> ਠੋਕ ਦਿੰਦਾ ਹੈਂ, ਤਾਂ ਵਧਾਈਆਂ: ਤੂੰ ਹੁਣੇ ਸਾਬਤ ਕਰ ਦਿੱਤਾ
+        ਕਿ ਤੇਰਾ ਦਿਮਾਗ਼ ਸਿਰਫ਼ ਸਜਾਵਟ ਲਈ ਹੈ, ਡਾਰਵਿਨ ਨੂੰ ਮਾਣ ਹੁੰਦਾ। <strong>ਪਲੀਜ਼ ਬੱਚੇ ਨਾ ਪੈਦਾ ਕਰੀਂ</strong>।
+      </p>
+    </header>
+
+    <section>
+      <h2>ਤੂੰ ਹੁਣੇ ਕੀਤਾ ਕੀ ਹੈ:</h2>
+      <p>ਕਿਸੇ ਨੇ ਤੈਨੂੰ ਇੱਕ ਸੱਚਾ ਸਵਾਲ ਪੁੱਛਿਆ, ਬਿਲਕੁਲ ਅਸਲੀ ਵਾਲਾ। ਉਹਦੇ ਕੋਲ ਪੂਰਾ ਸੰਦਰਭ ਸੀ ਤੇ ਨੀਅਤ ਵੀ ਸਾਫ਼ ਸੀ। ਉਹ
+        <em>ਖ਼ਾਸ ਕਰਕੇ</em> ਤੇਰੇ ਕੋਲ ਆਇਆ (ਕਿੰਨੀ ਵੱਡੀ ਇੱਜ਼ਤ ਹੈ)। ਫਿਰ ਤੂੰ ਉਹ ਸਵਾਲ ਚੁੱਕਿਆ, ਪ੍ਰੌਂਪਟ ਬਾਕਸ ਵਿੱਚ ਪਾ
+        ਦਿੱਤਾ, ਤੇ ਨਤੀਜਾ ਵਾਪਸ ਚਿਪਕਾ ਦਿੱਤਾ। ਲੱਗਿਆ ਹੋਣਾ ਕਿ ਅੱਜ ਤਾਂ ਬੜਾ ਪ੍ਰੋਡਕਟਿਵ ਤੇ ਹੁਸ਼ਿਆਰ ਬਣ ਗਿਆ... ਮਾਫ਼ ਕਰੀਂ, ਤੂੰ
+        ਰਤਾ ਵੀ ਹੁਸ਼ਿਆਰ ਨਹੀਂ ਹੋਇਆ। ਤੂੰ ਬੱਸ ਇਹ ਸਾਬਤ ਕੀਤਾ ਕਿ ਤੈਥੋਂ ਪੁੱਛਣ ਤੇ AI ਤੋਂ ਪੁੱਛਣ ਵਿੱਚ ਕੋਈ ਫ਼ਰਕ ਹੀ ਨਹੀਂ।
+      </p>
+
+      <p><em>ਅੰਦਾਜ਼ਾ ਲਾ, AI ਸਭ ਤੋਂ ਪਹਿਲਾਂ ਕਿਹਨੂੰ ਬਦਲੇਗਾ?</em></p>
+
+      <blockquote>
+        <span class="exhibit-label">ਜੇ ਗੱਲ ਸਾਫ਼ ਨਾ ਹੋਈ ਹੋਵੇ, ਤਾਂ ਆਹ ਰਿਹਾ ਤੇਰਾ ਜਵਾਬ:</span>
+        ਬਹੁਤ ਵਧੀਆ ਸਵਾਲ! ਇਸ ਸੂਖਮ ਵਿਸ਼ੇ ਉੱਤੇ ਵਿਚਾਰ ਕਰਦਿਆਂ ਕਈ ਮਹੱਤਵਪੂਰਨ ਪੱਖਾਂ ਨੂੰ ਧਿਆਨ ਵਿੱਚ ਰੱਖਣਾ ਜ਼ਰੂਰੀ ਹੈ, ਜਿਨ੍ਹਾਂ
+        ਬਾਰੇ ਕਿਸੇ ਨੇ ਸੱਚਮੁੱਚ ਸੋਚਣ ਦੀ ਤਕਲੀਫ਼ ਲਈ ਸੀ। ਆਓ ਇਸਨੂੰ ਕਦਮ-ਦਰ-ਕਦਮ ਸਮਝੀਏ, ਫਿਰ ਤੋਂ:<br><br>
+        1. <strong>ਸੰਦਰਭ ਨੂੰ ਸਮਝਣਾ</strong> — ਸਭ ਤੋਂ ਪਹਿਲਾਂ ਇੱਕ ਮਜ਼ਬੂਤ ਨੀਂਹ ਬਣਾਉਣੀ ਜ਼ਰੂਰੀ ਹੈ, ਕਿਉਂਕਿ ਤੂੰ ਸ਼ੁਰੂ
+        ਵਿੱਚ ਇਹੀ ਤਾਂ ਪੁੱਛਿਆ ਸੀ<br>
+        2. <strong>ਮੁੱਖ ਗੱਲਾਂ</strong> — ਇਸਦਾ ਮੁਲਾਂਕਣ ਕਰਦਿਆਂ ਧਿਆਨ ਰੱਖੋ ਕਿ... ਮੈਨੂੰ ਪੂਰਾ ਯਕੀਨ ਹੈ ਕਿ ਜੋ ਮੈਂ ਹੁਣ
+        ਕਹਿਣ ਜਾ ਰਿਹਾ ਹਾਂ, ਉਹ ਤੇਰੇ ਦਿਮਾਗ਼ ਵਿੱਚ ਕਦੇ ਨਹੀਂ ਆਇਆ ਹੋਣਾ<br>
+        3. <strong>ਸਭ ਤੋਂ ਵਧੀਆ ਤਰੀਕੇ</strong> — ਮਾਹਰ ਆਮ ਤੌਰ 'ਤੇ ਇਹੀ Google ਸਰਚ ਕਰਨ ਦੀ ਸਲਾਹ ਦਿੰਦੇ ਹਨ, ਜੋ ਤੂੰ 3
+        ਸਕਿੰਟਾਂ ਵਿੱਚ ਕਰ ਸਕਦਾ ਸੀ<br><br>
+
+        ਸਿੱਟਾ ਇਹ ਹੈ ਕਿ ਜਵਾਬ ਆਖ਼ਰਕਾਰ ਤੁਹਾਡੀ ਖ਼ਾਸ ਸਥਿਤੀ ਉੱਤੇ ਨਿਰਭਰ ਕਰਦਾ ਹੈ। ਉਮੀਦ ਹੈ ਇਸ ਨਾਲ ਮਦਦ ਮਿਲੇਗੀ, ਚੈਂਪੀਅਨ! ਜੇ
+        ਤੁਸੀਂ ਚਾਹੋ ਤਾਂ ਮੈਂ ਇਨ੍ਹਾਂ ਵਿੱਚੋਂ ਕਿਸੇ ਵੀ ਨੁਕਤੇ ਉੱਤੇ ਹੋਰ ਵਿਸਥਾਰ ਨਾਲ ਦੱਸ ਸਕਦਾ ਹਾਂ।
+
+        <em>ਵਾਹ... ਕਿੰਨਾ ਗਿਆਨ, ਨਵਾਂ ਬੁੱਧ ਸਾਡੇ ਵਿਚਕਾਰ ਹੈ। ਇਸ ਮੋਤੀ ਲਈ ਸ਼ੁਕਰੀਆ, ਜੋ ਮੈਨੂੰ ਆਪੇ ਹੀ ਮਿਲ ਜਾਣਾ ਸੀ।</em>
+      </blockquote>
+    </section>
+
+    <section>
+      <h2>ਇਹ ਸਰਾਸਰ ਬੇਇੱਜ਼ਤੀ ਹੈ</h2>
+      <p>ਜਿਹਨੂੰ ਤੂੰ ਜਵਾਬ ਭੇਜਿਆ ਹੈ, <strong>ਉਹਦੇ ਕੋਲ ਵੀ ਉਹੀ AI ਹੈ ਜੋ ਤੇਰੇ ਕੋਲ ਹੈ</strong>। ਜੇ ਉਹਨੂੰ ਉਹੀ ਘਸਿਆ-ਪਿਟਿਆ
+        LLM ਜਵਾਬ ਚਾਹੀਦਾ ਹੁੰਦਾ, ਤਾਂ ਤੈਥੋਂ ਗੱਲ ਕੀਤੇ ਬਿਨਾਂ ਸਕਿੰਟਾਂ ਵਿੱਚ ਮਿਲ ਜਾਂਦਾ, ਜੋ ਉਂਝ ਵੀ <em>ਵੱਧ ਸੌਖਾ</em> ਹੈ।
+        ਪਰ ਉਹਨੇ ਤੈਥੋਂ ਪੁੱਛਿਆ, ਕਿਉਂਕਿ ਉਹਨੂੰ <em>ਤੂੰ</em> ਚਾਹੀਦਾ ਸੀ। ਤੇਰੀ ਰਾਏ। ਤੇਰਾ ਤਜਰਬਾ। ਤੇਰੀ ਸਮਝ। ਉਹ ਸਭ, ਜੋ ਕਿਸੇ
+        ਮਾਡਲ ਕੋਲ ਨਹੀਂ।
+      </p>
+
+      <p>ਤੂੰ ਬਦਲੇ ਵਿੱਚ ਜੋ ਭੇਜਿਆ ਉਹਦਾ ਮਤਲਬ ਸੀ: <span class="marker">"ਮੇਰੇ ਕੋਲ ਤੇਰਾ ਸਵਾਲ ਢੰਗ ਨਾਲ ਪੜ੍ਹਨ ਤੇ ਸੱਚਮੁੱਚ
+          ਜਵਾਬ ਦੇਣ ਦਾ ਸਬਰ ਨਹੀਂ ਸੀ, ਸੋ ਆਹ ਲੈ, ਰੋਬੋਟ ਨੇ ਇਹੀ ਕਿਹਾ"</span>। ਇਹ ਗੱਲਬਾਤ ਵਿੱਚ <strong>ਈਮੇਲ ਫ਼ਾਰਵਰਡ
+          ਕਰਨ</strong> ਵਰਗਾ ਹੈ।
+      </p>
+
+      <p>ਤੂੰ ਕਿਸੇ ਨਾਲੋਂ ਵੱਧ ਹੁਸ਼ਿਆਰ ਨਹੀਂ ਹੈਂ। ਤੂੰ ਬੱਸ ਆਪਣੀ ਇੱਜ਼ਤ ਰੀਅਲ ਟਾਈਮ ਵਿੱਚ ਗੁਆ ਰਿਹਾ ਹੈਂ, ਤੇ ਉਹ ਵੀ ਇੰਝ ਕਿ
+        ਵਾਪਸ ਲੈਣੀ ਔਖੀ ਹੋਵੇਗੀ। ਤੂੰ ਆਪਣੀ ਰਾਏ ਵੇਚ ਕੇ ਇੱਕ ਫ਼ਾਰਚੂਨ ਕੁਕੀ ਵਾਲੀ ਲਾਈਨ ਖ਼ਰੀਦ ਲਈ ਤੇ ਅੱਗੇ ਤੁਰ ਪਿਆ।
+      </p>
+
+      <p>ਜੇ ਤੂੰ ਇਹੀ ਕਰਦਾ ਰਿਹਾ, ਤਾਂ <em>ਕੋਈ ਤੈਥੋਂ ਕੁਝ ਪੁੱਛੇਗਾ ਹੀ ਕਿਉਂ?</em></p>
+    </section>
+
+    <div class="shout">
+      ਮਾਡਲ ਚਿਪਕਾਉਣਾ<br><span>ਸੋਚਣਾ</span> ਨਹੀਂ ਹੈ।
+    </div>
+
+    <section>
+      <h2>ਇਲਾਜ ਬੜਾ ਸੌਖਾ ਹੈ</h2>
+      <ol>
+        <li>AI ਵਰਤ। ਵਧੀਆ ਸੰਦ ਹੈ। ਵਰਤਣ ਲਈ ਹੀ ਬਣਿਆ ਹੈ, ਪਰ ਸਾਡੀ ਸਾਰਿਆਂ ਦੀ ਅਕਲ ਦੀ ਖ਼ੈਰ ਲਈ, ਮਾਡਲ ਨੇ ਜੋ ਕਿਹਾ ਹੈ ਉਹ
+          <strong>ਪੜ੍ਹ</strong>। ਪੂਰਾ। ਹਾਂ, ਲਿਸਟਾਂ ਵੀ, ਕੋਡ ਵੀ, ਸਭ ਕੁਝ...
+        </li>
+        <li>ਤੈਅ ਕਰ ਕਿ ਕੀ ਕੰਮ ਦਾ ਹੈ ਤੇ ਕੀ ਨਹੀਂ। ਮਾਡਲ ਏਨੇ ਭਰੋਸੇ ਨਾਲ ਬੋਲਦੇ ਨੇ ਜਿਸਦਾ ਸਹੀ ਹੋਣ ਨਾਲ ਕੋਈ ਲੈਣਾ-ਦੇਣਾ ਹੀ
+          ਨਹੀਂ। ਅੱਧਾ ਤਾਂ ਸ਼ਾਇਦ ਗ਼ਲਤ ਹੋਵੇਗਾ, ਘਸਿਆ-ਪਿਟਿਆ ਹੋਵੇਗਾ, ਜਾਂ ਦੋਵੇਂ। ਤੇ ਇਹ ਉਦੋਂ ਹੈ ਜਦੋਂ ਉਹ ਸਿੱਧਾ
+          ਹੈਲੂਸਿਨੇਸ਼ਨ ਨਾ ਹੋਵੇ।
+        </li>
+        <li>ਆਪਣਾ ਜਵਾਬ ਆਪ ਲਿਖ। <em>ਤੇਰੇ</em> ਤਿੰਨ ਵਾਕ ਹਰ ਵਾਰ ਤਿੰਨ ਪੈਰ੍ਹਿਆਂ ਦੀ ਬਕਵਾਸ ਨਾਲੋਂ ਭਾਰੇ ਪੈਣਗੇ। ਅੱਜ ਤੱਕ ਕਿਸੇ
+          ਨੇ ਨਹੀਂ ਕਿਹਾ ਕਿ "ਵਾਹ ਬਈ... ਕਾਸ਼ ਇਹ ਜਵਾਬ ਹੋਰ ਲੰਮਾ ਹੁੰਦਾ, ਤੇ ਥੋੜ੍ਹਾ ਹੋਰ ਰੋਬੋਟ ਵਰਗਾ"।</li>
+        <li>ਜੇ ਸੱਚਮੁੱਚ ਮਾਡਲ ਨੂੰ ਕੋਟ ਕਰਨਾ ਜ਼ਰੂਰੀ ਹੈ, ਤਾਂ ਠੀਕ ਹੈ, ਉਹਦੇ ਵਿੱਚ ਚੰਗੀਆਂ ਚੀਜ਼ਾਂ ਵੀ ਹੁੰਦੀਆਂ ਨੇ! ਬੱਸ ਏਨਾ
+          ਦੱਸ ਦੇ ਕਿ <em>ਕਿਉਂ</em>। "ਮੈਂ Claude ਤੋਂ ਪੁੱਛਿਆ ਤੇ ਇਹ ਹਿੱਸਾ ਸੱਚਮੁੱਚ ਸਹੀ ਬੈਠਦਾ ਹੈ:", ਇਹ ਚੱਲੇਗਾ!
+          ਘੱਟੋ-ਘੱਟ ਤੂੰ ਪੜ੍ਹਿਆ ਤਾਂ, ਸਾਨੂੰ ਹਾਲੇ ਵੀ ਤੂੰ ਚੰਗਾ ਲੱਗਦਾ ਹੈਂ
+        </li>
+        <li>ਜੇ ਕਹਿਣ ਨੂੰ ਕੁਝ ਨਹੀਂ, ਤਾਂ <strong>ਕੁਝ ਨਾ ਕਹਿ</strong>। ਚੁੱਪ ਵੀ ਇੱਕ ਯੋਗਦਾਨ ਹੈ। ਜਾਂ ਕਹਿ ਦੇ "ਮੇਰੇ ਕੋਲ
+          ਜੋੜਨ ਨੂੰ ਕੁਝ ਨਹੀਂ"। ਸਾਰਿਆਂ ਦਾ ਵਕਤ ਬਚੇਗਾ।</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>"ਪਰ ਮੈਂ ਤਾਂ ਮਦਦ ਕਰਨੀ ਸੀ!"</h2>
+      <p>ਨਹੀਂ, ਤੂੰ ਨਹੀਂ ਕਰਨੀ ਸੀ। ਤੂੰ ਮਦਦ ਕਰਨ ਦੀ ਮਿਹਨਤ ਕੀਤੇ ਬਿਨਾਂ ਮਦਦਗਾਰ <em>ਦਿਸਣਾ</em> ਚਾਹੁੰਦਾ ਸੀ। ਦੋਵਾਂ ਵਿੱਚ
+        ਫ਼ਰਕ ਹੈ।
+      </p>
+      <p>ਮਦਦ ਕਰਨੀ ਯਾਨੀ ਧਿਆਨ ਨਾਲ <strong>ਪੜ੍ਹਨਾ</strong>, <strong>ਸੋਚਣਾ</strong>, ਤੇ ਅਜਿਹਾ ਕੁਝ <strong>ਜਵਾਬ
+          ਦੇਣਾ</strong> ਜੋ ਸਿਰਫ਼ ਤੂੰ ਕਹਿ ਸਕਦਾ ਸੀ, ਜਾਂ ਘੱਟੋ-ਘੱਟ ਜਿਹਨੂੰ ਤੂੰ ਸੰਵਾਰਿਆ ਹੋਵੇ। AI ਦਾ ਮਾਲ ਚਿਪਕਾਉਣਾ
+        ਸਾਹਮਣੇ ਵਾਲੇ ਨੂੰ ਕਹਿੰਦਾ ਹੈ ਕਿ ਉਹਦਾ ਸਵਾਲ ਤੇਰੇ ਵਕਤ ਦੇ ਲਾਇਕ ਨਹੀਂ ਸੀ, ਬੱਸ ਇੱਕ ਚੈਟਬੋਟ ਦੇ ਲਾਇਕ ਸੀ। ਤੈਨੂੰ ਕਿਵੇਂ
+        ਲੱਗਦਾ?
+      </p>
+    </section>
+
+    <section>
+      <h2>ਇਹ ਸਾਈਟ AI-ਵਿਰੋਧੀ ਨਹੀਂ ਹੈ।</h2>
+      <p>ਟੂਲ ਵਰਤੋ। ਰੋਜ਼ ਵਰਤੋ। ਤੇਜ਼ੀ ਨਾਲ ਡਰਾਫ਼ਟ ਬਣਾਉਣ ਲਈ, ਵੱਧ ਰਚਨਾਤਮਕ ਹੋਣ ਲਈ, ਵੱਧ ਸਿੱਖਣ ਲਈ, ਅਟਕਣ 'ਤੇ ਅੱਗੇ ਵਧਣ
+        ਲਈ। ਵਧੀਆ। ਉਹ ਇਸੇ ਲਈ ਬਣੇ ਨੇ। <strong>ਉਹਨਾਂ ਦਾ ਆਉਟਪੁੱਟ ਸ਼ੁਰੂਆਤ ਹੈ, ਡਿਲੀਵਰੇਬਲ ਨਹੀਂ।</strong> ਉਹਨੂੰ ਕਿਸੇ
+        ਜੂਨੀਅਰ ਇੰਟਰਨ ਦੇ ਪਹਿਲੇ ਡਰਾਫ਼ਟ ਵਾਂਗ ਲਵੋ, ਕਿਉਂਕਿ ਉਹ ਬਿਲਕੁਲ ਉਹੀ ਹੈ। ਐਡਿਟ ਕਰੋ। ਕੱਟੋ। ਉਸ ਨਾਲ ਅਸਹਿਮਤ ਹੋਵੋ।
+        ਉਹਨੂੰ ਆਪਣਾ ਬਣਾਓ, ਨਹੀਂ ਤਾਂ ਨਾ ਭੇਜੋ।
+      </p>
+    </section>
+
+    <section>
+      <h2>ਇਹਦੀ ਵਰਤੋਂ ਕਿਵੇਂ ਕਰੀਏ?</h2>
+      <p>ਅਗਲੀ ਵਾਰ ਕੋਈ ਤੇਰੇ DM ਵਿੱਚ, ਤੇਰੇ Slack ਵਿੱਚ, ਤੇਰੇ ਕੋਡ ਰੀਵਿਊ ਵਿੱਚ, ਸੱਚ ਕਹੀਏ ਤਾਂ ਕਿਤੇ ਵੀ, ਬਿਨਾਂ ਪੜ੍ਹੇ LLM
+        ਟੈਕਸਟ ਦੀ ਕੰਧ ਠੋਕ ਦੇਵੇ, ਤਾਂ ਉਹਨੂੰ ਇਹ ਭੇਜ:</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" data-copy-path="/angry/pa" type="button" class="url-tag-big"
+          data-copy-aria="{domain} ਨੂੰ ਕਲਿੱਪਬੋਰਡ ਉੱਤੇ ਕਾਪੀ ਕਰੋ" data-copied-text="ਕਾਪੀ ਹੋ ਗਿਆ!">dontpastetheai.com</button></p>
+      <p class="u-center u-small u-muted u-mt-md">ਕਾਪੀ ਕਰਨ ਲਈ ਕਲਿੱਕ ਕਰ।</p>
+    </section>
+
+    <section>
+      <h2>ਬਹੁਤ ਭਾਰੀ ਪੈ ਗਿਆ?</h2>
+      <p>ਕੋਈ ਗੱਲ ਨਹੀਂ। ਦਫ਼ਤਰ ਵਿੱਚ ਚੱਲਣ ਵਾਲਾ ਵਰਜ਼ਨ ਭੇਜਣਾ ਹੈ? ਉਹ ਵੀ ਹਾਜ਼ਰ ਹੈ:</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" data-variant-toggle href="../">← ਮੈਂ ਸਰਮਾਏਦਾਰੀ ਦਾ ਗ਼ੁਲਾਮ
+          ਹਾਂ</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— ਸਤਿਕਾਰ ਸਹਿਤ,<br> ਸ਼ਾਇਦ ਅਸੀਂ ਸਾਰੇ</div>
+      <small><a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> ਤੇ
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a> ਦਾ ਰੂਹਾਨੀ ਚਚੇਰਾ
+        ਭਰਾ।<br>ਇਹ ਪੰਨਾ <a href="https://github.com/khaosdoctor/dontquotetheai/issues/31" target="_blank"
+          rel="noopener">ਕਿਸੇ ਰੈਂਡਮ ਬੰਦੇ</a> ਨੇ ਲਿਖਿਆ ਹੈ (ਹੈਰਾਨੀ ਦੀ ਗੱਲ ਹੈ ਨਾ?)। ਤੇ ਸੱਚਮੁੱਚ ਪਰੂਫ਼ਰੀਡ ਵੀ ਕੀਤਾ ਗਿਆ
+        ਹੈ।
+      </small>
+    </div>
+
+    <div class="footer">
+      <p><em>ਜੇ ਕਿਸੇ ਨੇ ਤੈਨੂੰ ਇਹ ਲਿੰਕ ਭੇਜਿਆ ਹੈ, ਤਾਂ ਉਹਦੇ 'ਤੇ <a href="https://www.youtube.com/watch?v=xzpndHtdl9A"
+            target="_blank" rel="noopener">ਗੁੱਸਾ</a> ਨਾ ਕਰੀਂ। ਉਹਨੇ ਚੰਗੀ ਨੀਅਤ ਨਾਲ ਭੇਜਿਆ ਹੈ। ਪੜ੍ਹ, ਸਾਹ ਲੈ, ਤੇ ਅਗਲਾ
+          ਜਵਾਬ ਆਪ ਲਿਖ।</em></p>
+      <p>ਵਿਅੰਗ ਹੈ (ਜੇ ਖੁੰਝ ਗਿਆ ਹੋਵੇ ਤਾਂ)। ਸ਼ੇਅਰ ਕਰਨ, ਬਦਲਣ ਤੇ ਅਨੁਵਾਦ ਕਰਨ ਲਈ ਆਜ਼ਾਦ —
+        <a href="https://github.com/khaosdoctor/dontpastetheai" target="_blank" rel="noopener">GitHub ਉੱਤੇ PR ਦਾ
+          ਸਵਾਗਤ ਹੈ</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>

--- a/assets/og-image-hi.svg
+++ b/assets/og-image-hi.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <rect width="1200" height="630" fill="#ede2c4"/>
+
+  <ellipse cx="1020" cy="95" rx="400" ry="300" fill="#5a3214" opacity="0.08"/>
+  <ellipse cx="120" cy="565" rx="300" ry="200" fill="#5a3214" opacity="0.05"/>
+
+  <text x="600" y="225" text-anchor="middle" font-family="Noto Sans Devanagari" font-size="84" fill="#15120e">ओहो, तुमने</text>
+  <text x="600" y="335" text-anchor="middle" font-family="Noto Sans Devanagari" font-size="84" fill="#15120e"><tspan fill="#a82820">AI</tspan> बिना पढ़े ही</text>
+  <text x="600" y="445" text-anchor="middle" font-family="Noto Sans Devanagari" font-size="84" fill="#15120e">चिपका दिया।</text>
+
+  <g transform="translate(740,540) rotate(-1)">
+    <rect x="4" y="4" width="380" height="60" fill="#15120e"/>
+    <rect x="0" y="0" width="380" height="60" fill="#f5d547" stroke="#15120e" stroke-width="3"/>
+    <text x="190" y="42" text-anchor="middle" font-family="Noto Sans Devanagari" font-size="30" fill="#15120e">dontpastetheai.com</text>
+  </g>
+</svg>

--- a/assets/og-image-pa.svg
+++ b/assets/og-image-pa.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <rect width="1200" height="630" fill="#ede2c4"/>
+
+  <ellipse cx="1020" cy="95" rx="400" ry="300" fill="#5a3214" opacity="0.08"/>
+  <ellipse cx="120" cy="565" rx="300" ry="200" fill="#5a3214" opacity="0.05"/>
+
+  <text x="600" y="225" text-anchor="middle" font-family="Noto Sans Gurmukhi" font-size="84" fill="#15120e">ਓਹੋ, ਤੂੰ</text>
+  <text x="600" y="335" text-anchor="middle" font-family="Noto Sans Gurmukhi" font-size="84" fill="#15120e"><tspan fill="#a82820">AI</tspan> ਬਿਨਾਂ ਪੜ੍ਹੇ</text>
+  <text x="600" y="445" text-anchor="middle" font-family="Noto Sans Gurmukhi" font-size="84" fill="#15120e">ਚਿਪਕਾ ਦਿੱਤਾ।</text>
+
+  <g transform="translate(740,540) rotate(-1)">
+    <rect x="4" y="4" width="380" height="60" fill="#15120e"/>
+    <rect x="0" y="0" width="380" height="60" fill="#f5d547" stroke="#15120e" stroke-width="3"/>
+    <text x="190" y="42" text-anchor="middle" font-family="Noto Sans Gurmukhi" font-size="30" fill="#15120e">dontpastetheai.com</text>
+  </g>
+</svg>

--- a/assets/translations.json
+++ b/assets/translations.json
@@ -36,6 +36,13 @@
       "file": "fr.html"
     },
     {
+      "code": "hi",
+      "hreflang": "hi",
+      "locale": "hi_IN",
+      "label": "HI — हिन्दी",
+      "file": "hi.html"
+    },
+    {
       "code": "hu",
       "hreflang": "hu",
       "locale": "hu_HU",
@@ -191,6 +198,13 @@
         "locale": "fr_FR",
         "label": "FR — Français",
         "file": "fr.html"
+      },
+      {
+        "code": "hi",
+        "hreflang": "hi",
+        "locale": "hi_IN",
+        "label": "HI — हिन्दी",
+        "file": "hi.html"
       },
       {
         "code": "hu",

--- a/assets/translations.json
+++ b/assets/translations.json
@@ -92,6 +92,13 @@
       "file": "ne.html"
     },
     {
+      "code": "pa",
+      "hreflang": "pa",
+      "locale": "pa_IN",
+      "label": "PA — ਪੰਜਾਬੀ",
+      "file": "pa.html"
+    },
+    {
       "code": "pl",
       "hreflang": "pl",
       "locale": "pl_PL",
@@ -254,6 +261,13 @@
         "locale": "ne_NP",
         "label": "NE — नेपाली",
         "file": "ne.html"
+      },
+      {
+        "code": "pa",
+        "hreflang": "pa",
+        "locale": "pa_IN",
+        "label": "PA — ਪੰਜਾਬੀ",
+        "file": "pa.html"
       },
       {
         "code": "pl",

--- a/hi.html
+++ b/hi.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="hi">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>कृपया AI पेस्ट मत कीजिए।</title>
+  <meta name="description" content="अगर कोई आपसे कुछ पूछता है, तो अपना जवाब भेजिए। AI का नहीं।">
+  <meta property="og:title" content="कृपया AI पेस्ट मत कीजिए।">
+  <meta property="og:description" content="अगर कोई आपसे कुछ पूछता है, तो अपना जवाब भेजिए। AI का नहीं।">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-hi.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="hi_IN">
+  <meta property="og:url" content="https://dontpastetheai.com/hi.html">
+  <link rel="canonical" href="https://dontpastetheai.com/hi.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image-hi.png">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Noto+Sans+Devanagari:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    :root {
+      --font-type: "Kalam", cursive;
+      --font-mono: "Noto Sans Devanagari", sans-serif;
+    }
+  </style>
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/hu.html">
+  <link rel="alternate" hreflang="hy" href="https://dontpastetheai.com/hy.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/">
+  <!-- hreflang:end -->
+  <script src="assets/translations.js" defer></script>
+  <script src="assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>कोई और भाषा पसंद है?</span>
+        <label class="lang" aria-label="भाषा">
+          <select data-lang-select>
+            <option>HI — हिन्दी</option>
+          </select>
+        </label>
+      </div>
+      <h1>कृपया <span class="yell">AI</span><br>पेस्ट मत कीजिए।</h1>
+      <p class="lede">जब कोई आपसे कुछ पूछता है, तो उसे <em>आपका</em> जवाब चाहिए होता है।
+        <span class="marker">ChatGPT के टेक्स्ट की दीवार</span> नहीं। किसी इंसान का छोटा-सा जवाब हमेशा रोबोट के जवाब से
+        ज़्यादा कीमती रहेगा, भले ही रोबोट सही हो।</p>
+    </header>
+
+    <section>
+      <h2>हुआ क्या</h2>
+      <p>किसी ने आपसे एक ईमानदार सवाल पूछा। आपने उसे चैटबॉट में डाल दिया, जवाब कॉपी किया, और वापस भेज दिया।
+        लगा कि झटपट काम हो गया। लगा कि मदद हो गई। नहीं हुई।</p>
+      <p>भले ही ऐसा न दिखे, लेकिन सामने वाले के पास <strong>वही टूल हैं जो आपके पास हैं</strong>। उसे अगर वही
+        घिसा-पिटा जवाब चाहिए होता, तो दो सेकंड में मिल जाता। उसने <em>आपसे</em> इसलिए पूछा क्योंकि उसे आपकी राय
+        चाहिए थी... आपका संदर्भ, आपकी समझ, आपका फ़ैसला।</p>
+
+      <p>दुनिया ऐसे लोगों से भरी पड़ी है जो न पढ़ना चाहते हैं, न सोचना। आप उनमें से मत बनिए।</p>
+    </section>
+
+    <section>
+      <h2>इसके बजाय ये कीजिए</h2>
+      <ol>
+        <li>AI इस्तेमाल कीजिए। सच में! ड्राफ़्ट बनाने के लिए ये बढ़िया औज़ार है। बस <strong>जो उसने दिया है उसे पढ़
+            लीजिए</strong>, फिर अपना वर्शन लिखिए, या उस टेक्स्ट को सँवारिए। AI और जवाब के बीच बिचौलिए मत बनिए।</li>
+        <li>जो हिस्सा सवाल का असली जवाब देता है उसे रखिए, बाकी छोड़ दीजिए। तीन वाक्य काफ़ी हैं, और अगर वे कॉपी किए हुए
+          भी हों, तो कम से कम आपने उन्हें पढ़ा तो है।</li>
+        <li>अगर मॉडल के जवाब का कोई हिस्सा वाक़ई काम का है, तो उसे कोट कीजिए और बताइए कि <em>क्यों</em>।
+          <span class="marker"><em>"मैंने Claude से पूछा था, और ये वाली बात सही लगती है:"</em></span>.
+        </li>
+        <li>अगर कहने को कुछ नहीं है, तो साफ़ कह दीजिए। <span class="marker"><em>"इस पर मेरी कोई पक्की राय
+                नहीं है"</em></span>. चुप रहना भी एक विकल्प है।
+        </li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>किसी को ये भेजना है?</h2>
+      <p>अगर किसी ने अभी-अभी आपके DM, Slack या कोड रिव्यू में LLM टेक्स्ट की दीवार ठोक दी है, तो आप उन्हें ये लिंक
+        भेज सकते हैं।</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+          data-copy-aria="{domain} को क्लिपबोर्ड पर कॉपी करें" data-copied-text="कॉपी हो गया!">dontpastetheai.com</button></p>
+      <p class="u-center u-small u-muted u-mt-md">कॉपी करने के लिए क्लिक कीजिए।</p>
+    </section>
+
+    <section>
+      <h2>थोड़ा कड़ा वर्शन चाहिए?</h2>
+      <p>अगर आप <em>ज़्यादा भावनाओं वाला</em> वर्शन भेजना चाहते हैं, तो वो भी हाज़िर है!</p>
+      <p class="u-center u-mt-lg"><a class="cta-angry" data-variant-toggle href="angry/index.html">मुझे रिश्ते जला
+          देने हैं 🔥</a></p>
+      <p class="u-center u-small u-muted u-mt-md">दफ़्तर में शायद इसका स्वागत न हो, पर आपकी मर्ज़ी</p>
+    </section>
+
+    <section>
+      <h2>आप शिक्षक हैं?</h2>
+      <p>अगर आपके छात्र आपको AI से लिखा हुआ शोध-पत्र या प्रोजेक्ट भेजते हैं, तो आप उन्हें ये लिंक भेज सकते हैं:</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" data-student-toggle href="student/">उन्हें क्लास में भेजिए</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— साथ में... प्यार? <br>हम सब</div>
+      <small><a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> और
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a> का आध्यात्मिक चचेरा
+        भाई।<br>लिखा है किसी रैंडम आदमी ने (<a href="https://github.com/khaosdoctor/dontquotetheai/issues/31"
+          target="_blank" rel="noopener">यक़ीन करें या न करें</a>)। बिल्कुल पुराने ज़माने की तरह।</small>
+    </div>
+
+    <div class="footer">
+      <p><em>अगर किसी ने आपको ये लिंक भेजा है: वो चाहता है कि आप इस पर ज़रा सोचें। पढ़िए, साँस लीजिए, और अगला जवाब
+          ख़ुद लिखिए।</em></p>
+      <p>ये साइट व्यंग्य है (अगर आपका ध्यान न गया हो तो) — कॉपी कीजिए, बदलिए, अनुवाद कीजिए, बेझिझक।
+        <a href="https://github.com/khaosdoctor/dontquotetheai" target="_blank" rel="noopener">GitHub पर PR का स्वागत
+          है</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>

--- a/pa.html
+++ b/pa.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="pa">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ਕਿਰਪਾ ਕਰਕੇ AI ਪੇਸਟ ਨਾ ਕਰੋ।</title>
+  <meta name="description" content="ਜੇ ਕੋਈ ਤੁਹਾਨੂੰ ਕੁਝ ਪੁੱਛਦਾ ਹੈ, ਤਾਂ ਆਪਣਾ ਜਵਾਬ ਭੇਜੋ। AI ਦਾ ਨਹੀਂ।">
+  <meta property="og:title" content="ਕਿਰਪਾ ਕਰਕੇ AI ਪੇਸਟ ਨਾ ਕਰੋ।">
+  <meta property="og:description" content="ਜੇ ਕੋਈ ਤੁਹਾਨੂੰ ਕੁਝ ਪੁੱਛਦਾ ਹੈ, ਤਾਂ ਆਪਣਾ ਜਵਾਬ ਭੇਜੋ। AI ਦਾ ਨਹੀਂ।">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-pa.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="pa_IN">
+  <meta property="og:url" content="https://dontpastetheai.com/pa.html">
+  <link rel="canonical" href="https://dontpastetheai.com/pa.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image-pa.png">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Noto+Serif+Gurmukhi:wght@400;700&family=Noto+Sans+Gurmukhi:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    :root {
+      --font-type: "Noto Serif Gurmukhi", serif;
+      --font-mono: "Noto Sans Gurmukhi", sans-serif;
+    }
+  </style>
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/hu.html">
+  <link rel="alternate" hreflang="hy" href="https://dontpastetheai.com/hy.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/">
+  <!-- hreflang:end -->
+  <script src="assets/translations.js" defer></script>
+  <script src="assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>ਕੋਈ ਹੋਰ ਭਾਸ਼ਾ ਪਸੰਦ ਹੈ?</span>
+        <label class="lang" aria-label="ਭਾਸ਼ਾ">
+          <select data-lang-select>
+            <option>PA — ਪੰਜਾਬੀ</option>
+          </select>
+        </label>
+      </div>
+      <h1>ਕਿਰਪਾ ਕਰਕੇ <span class="yell">AI</span><br>ਪੇਸਟ ਨਾ ਕਰੋ।</h1>
+      <p class="lede">ਜਦੋਂ ਕੋਈ ਤੁਹਾਨੂੰ ਕੁਝ ਪੁੱਛਦਾ ਹੈ, ਤਾਂ ਉਹਨੂੰ <em>ਤੁਹਾਡਾ</em> ਜਵਾਬ ਚਾਹੀਦਾ ਹੁੰਦਾ ਹੈ।
+        <span class="marker">ChatGPT ਦੇ ਟੈਕਸਟ ਦੀ ਕੰਧ</span> ਨਹੀਂ। ਕਿਸੇ ਬੰਦੇ ਦਾ ਛੋਟਾ ਜਿਹਾ ਜਵਾਬ ਹਮੇਸ਼ਾ ਰੋਬੋਟ ਦੇ ਜਵਾਬ
+        ਨਾਲੋਂ ਵੱਧ ਕੀਮਤੀ ਰਹੇਗਾ, ਭਾਵੇਂ ਰੋਬੋਟ ਸਹੀ ਹੀ ਹੋਵੇ।</p>
+    </header>
+
+    <section>
+      <h2>ਹੋਇਆ ਕੀ</h2>
+      <p>ਕਿਸੇ ਨੇ ਤੁਹਾਨੂੰ ਇੱਕ ਇਮਾਨਦਾਰ ਸਵਾਲ ਪੁੱਛਿਆ। ਤੁਸੀਂ ਉਹਨੂੰ ਚੈਟਬੋਟ ਵਿੱਚ ਪਾ ਦਿੱਤਾ, ਜਵਾਬ ਕਾਪੀ ਕੀਤਾ, ਤੇ ਵਾਪਸ ਭੇਜ
+        ਦਿੱਤਾ। ਲੱਗਾ ਕਿ ਕੰਮ ਝੱਟ ਹੋ ਗਿਆ। ਲੱਗਾ ਕਿ ਮਦਦ ਹੋ ਗਈ। ਨਹੀਂ ਹੋਈ।</p>
+      <p>ਭਾਵੇਂ ਇੰਝ ਨਾ ਲੱਗੇ, ਪਰ ਸਾਹਮਣੇ ਵਾਲੇ ਕੋਲ <strong>ਉਹੀ ਟੂਲ ਹਨ ਜੋ ਤੁਹਾਡੇ ਕੋਲ ਹਨ</strong>। ਜੇ ਉਹਨੂੰ ਉਹੀ
+        ਘਸਿਆ-ਪਿਟਿਆ ਜਵਾਬ ਚਾਹੀਦਾ ਹੁੰਦਾ, ਤਾਂ ਦੋ ਸਕਿੰਟਾਂ ਵਿੱਚ ਮਿਲ ਜਾਂਦਾ। ਉਹਨੇ <em>ਤੁਹਾਨੂੰ</em> ਇਸ ਕਰਕੇ ਪੁੱਛਿਆ ਕਿਉਂਕਿ
+        ਉਹਨੂੰ ਤੁਹਾਡੀ ਰਾਏ ਚਾਹੀਦੀ ਸੀ... ਤੁਹਾਡਾ ਸੰਦਰਭ, ਤੁਹਾਡੀ ਸਮਝ, ਤੁਹਾਡਾ ਫ਼ੈਸਲਾ।</p>
+
+      <p>ਦੁਨੀਆ ਅਜਿਹੇ ਲੋਕਾਂ ਨਾਲ ਭਰੀ ਪਈ ਹੈ ਜੋ ਨਾ ਪੜ੍ਹਨਾ ਚਾਹੁੰਦੇ ਨੇ, ਨਾ ਸੋਚਣਾ। ਤੁਸੀਂ ਉਹਨਾਂ ਵਿੱਚੋਂ ਨਾ ਬਣੋ।</p>
+    </section>
+
+    <section>
+      <h2>ਇਸ ਦੀ ਥਾਂ ਇਹ ਕਰੋ</h2>
+      <ol>
+        <li>AI ਵਰਤੋ। ਸੱਚੀਂ! ਡਰਾਫ਼ਟ ਬਣਾਉਣ ਲਈ ਇਹ ਵਧੀਆ ਸੰਦ ਹੈ। ਬੱਸ <strong>ਜੋ ਉਹਨੇ ਦਿੱਤਾ ਹੈ ਉਹ ਪੜ੍ਹ ਲਵੋ</strong>, ਫਿਰ
+          ਆਪਣਾ ਵਰਜ਼ਨ ਲਿਖੋ, ਜਾਂ ਉਸ ਲਿਖਤ ਨੂੰ ਸੰਵਾਰੋ। AI ਤੇ ਜਵਾਬ ਵਿਚਾਲੇ ਵਿਚੋਲੇ ਨਾ ਬਣੋ।</li>
+        <li>ਜਿਹੜਾ ਹਿੱਸਾ ਸਵਾਲ ਦਾ ਅਸਲੀ ਜਵਾਬ ਦਿੰਦਾ ਹੈ ਉਹ ਰੱਖੋ, ਬਾਕੀ ਛੱਡ ਦਿਓ। ਤਿੰਨ ਵਾਕ ਕਾਫ਼ੀ ਨੇ, ਤੇ ਜੇ ਉਹ ਕਾਪੀ ਕੀਤੇ
+          ਵੀ ਹੋਣ, ਤਾਂ ਘੱਟੋ-ਘੱਟ ਤੁਸੀਂ ਉਹ ਪੜ੍ਹੇ ਤਾਂ ਹਨ।</li>
+        <li>ਜੇ ਮਾਡਲ ਦੇ ਜਵਾਬ ਦਾ ਕੋਈ ਹਿੱਸਾ ਸੱਚਮੁੱਚ ਕੰਮ ਦਾ ਹੈ, ਤਾਂ ਉਹਨੂੰ ਕੋਟ ਕਰੋ ਤੇ ਦੱਸੋ ਕਿ <em>ਕਿਉਂ</em>।
+          <span class="marker"><em>"ਮੈਂ Claude ਤੋਂ ਪੁੱਛਿਆ ਸੀ, ਤੇ ਇਹ ਵਾਲੀ ਗੱਲ ਠੀਕ ਲੱਗਦੀ ਹੈ:"</em></span>.
+        </li>
+        <li>ਜੇ ਕਹਿਣ ਨੂੰ ਕੁਝ ਨਹੀਂ ਹੈ, ਤਾਂ ਸਾਫ਼ ਕਹਿ ਦਿਓ। <span class="marker"><em>"ਇਸ ਬਾਰੇ ਮੇਰੀ ਕੋਈ ਪੱਕੀ ਰਾਏ
+                ਨਹੀਂ"</em></span>. ਚੁੱਪ ਰਹਿਣਾ ਵੀ ਇੱਕ ਬਦਲ ਹੈ।
+        </li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>ਕਿਸੇ ਨੂੰ ਇਹ ਭੇਜਣਾ ਹੈ?</h2>
+      <p>ਜੇ ਕਿਸੇ ਨੇ ਹੁਣੇ-ਹੁਣੇ ਤੁਹਾਡੇ DM, Slack ਜਾਂ ਕੋਡ ਰੀਵਿਊ ਵਿੱਚ LLM ਟੈਕਸਟ ਦੀ ਕੰਧ ਠੋਕ ਦਿੱਤੀ ਹੈ, ਤਾਂ ਤੁਸੀਂ
+        ਉਹਨਾਂ ਨੂੰ ਇਹ ਲਿੰਕ ਭੇਜ ਸਕਦੇ ਹੋ।</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+          data-copy-aria="{domain} ਨੂੰ ਕਲਿੱਪਬੋਰਡ ਉੱਤੇ ਕਾਪੀ ਕਰੋ" data-copied-text="ਕਾਪੀ ਹੋ ਗਿਆ!">dontpastetheai.com</button></p>
+      <p class="u-center u-small u-muted u-mt-md">ਕਾਪੀ ਕਰਨ ਲਈ ਕਲਿੱਕ ਕਰੋ।</p>
+    </section>
+
+    <section>
+      <h2>ਥੋੜ੍ਹਾ ਸਖ਼ਤ ਵਰਜ਼ਨ ਚਾਹੀਦਾ ਹੈ?</h2>
+      <p>ਜੇ ਤੁਸੀਂ <em>ਵੱਧ ਜਜ਼ਬਾਤਾਂ ਵਾਲਾ</em> ਵਰਜ਼ਨ ਭੇਜਣਾ ਚਾਹੁੰਦੇ ਹੋ, ਤਾਂ ਉਹ ਵੀ ਹਾਜ਼ਰ ਹੈ!</p>
+      <p class="u-center u-mt-lg"><a class="cta-angry" data-variant-toggle href="angry/index.html">ਮੈਂ ਪੁਲ ਸਾੜਨੇ ਨੇ
+          🔥</a></p>
+      <p class="u-center u-small u-muted u-mt-md">ਦਫ਼ਤਰ ਵਿੱਚ ਸ਼ਾਇਦ ਇਸ ਦਾ ਸਵਾਗਤ ਨਾ ਹੋਵੇ, ਪਰ ਤੁਹਾਡੀ ਮਰਜ਼ੀ</p>
+    </section>
+
+    <section>
+      <h2>ਤੁਸੀਂ ਅਧਿਆਪਕ ਹੋ?</h2>
+      <p>ਜੇ ਤੁਹਾਡੇ ਵਿਦਿਆਰਥੀ ਤੁਹਾਨੂੰ AI ਤੋਂ ਲਿਖਵਾਇਆ ਖੋਜ-ਪੱਤਰ ਜਾਂ ਪ੍ਰੋਜੈਕਟ ਭੇਜਦੇ ਹਨ, ਤਾਂ ਤੁਸੀਂ ਉਹਨਾਂ ਨੂੰ ਇਹ ਲਿੰਕ
+        ਭੇਜ ਸਕਦੇ ਹੋ:</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" data-student-toggle href="student/">ਉਹਨਾਂ ਨੂੰ ਕਲਾਸ ਵਿੱਚ
+          ਭੇਜੋ</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— ਨਾਲੇ... ਪਿਆਰ? <br>ਅਸੀਂ ਸਾਰੇ</div>
+      <small><a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> ਤੇ
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a> ਦਾ ਰੂਹਾਨੀ ਚਚੇਰਾ
+        ਭਰਾ।<br>ਲਿਖਿਆ ਕਿਸੇ ਰੈਂਡਮ ਬੰਦੇ ਨੇ (<a href="https://github.com/khaosdoctor/dontquotetheai/issues/31"
+          target="_blank" rel="noopener">ਯਕੀਨ ਕਰੋ ਜਾਂ ਨਾ</a>)। ਬਿਲਕੁਲ ਪੁਰਾਣੇ ਵੇਲਿਆਂ ਵਾਂਗ।</small>
+    </div>
+
+    <div class="footer">
+      <p><em>ਜੇ ਕਿਸੇ ਨੇ ਤੁਹਾਨੂੰ ਇਹ ਲਿੰਕ ਭੇਜਿਆ ਹੈ: ਉਹ ਚਾਹੁੰਦਾ ਹੈ ਕਿ ਤੁਸੀਂ ਇਸ ਬਾਰੇ ਜ਼ਰਾ ਸੋਚੋ। ਪੜ੍ਹੋ, ਸਾਹ ਲਵੋ, ਤੇ
+          ਅਗਲਾ ਜਵਾਬ ਆਪ ਲਿਖੋ।</em></p>
+      <p>ਇਹ ਸਾਈਟ ਵਿਅੰਗ ਹੈ (ਜੇ ਤੁਹਾਡਾ ਧਿਆਨ ਨਾ ਗਿਆ ਹੋਵੇ ਤਾਂ) — ਕਾਪੀ ਕਰੋ, ਬਦਲੋ, ਅਨੁਵਾਦ ਕਰੋ, ਬੇਝਿਜਕ।
+        <a href="https://github.com/khaosdoctor/dontquotetheai" target="_blank" rel="noopener">GitHub ਉੱਤੇ PR ਦਾ
+          ਸਵਾਗਤ ਹੈ</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>

--- a/student/hi.html
+++ b/student/hi.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="hi" data-page="student">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>कृपया AI जमा मत कीजिए।</title>
+  <meta name="description" content="AI आपके शोध-पत्र में मदद कर सकता है। वो आपकी जगह सोच नहीं सकता।">
+  <meta property="og:title" content="कृपया AI जमा मत कीजिए।">
+  <meta property="og:description" content="AI आपके शोध-पत्र में मदद कर सकता है। वो आपकी जगह सोच नहीं सकता।">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-hi.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="hi_IN">
+  <meta property="og:url" content="https://dontpastetheai.com/student/hi.html">
+  <link rel="canonical" href="https://dontpastetheai.com/student/hi.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image-hi.png">
+  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Noto+Sans+Devanagari:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="../styles.css">
+  <style>
+    :root {
+      --font-type: "Kalam", cursive;
+      --font-mono: "Noto Sans Devanagari", sans-serif;
+    }
+  </style>
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/student/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/student/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/student/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/student/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/student/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/student/hu.html">
+  <link rel="alternate" hreflang="hy" href="https://dontpastetheai.com/student/hy.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/student/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/student/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/student/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/student/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/student/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/student/">
+  <!-- hreflang:end -->
+  <script src="../assets/translations.js" defer></script>
+  <script src="../assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>कोई और भाषा पसंद है?</span>
+        <label class="lang" aria-label="भाषा">
+          <select data-lang-select>
+            <option>HI — हिन्दी</option>
+          </select>
+        </label>
+      </div>
+      <h1>कृपया <span class="yell">AI</span><br>जमा मत कीजिए।</h1>
+      <p class="lede">जब मैं आपसे <em>आपका</em> शोध-पत्र माँगता हूँ, तो मैं आपकी सोच माँग रहा होता हूँ। किसी चैटबॉट
+        में डाली गई PDF का जवाब वापस चिपकाया हुआ नहीं। <span class="marker">AI आपके काम में मदद कर सकता है</span>।
+        वो आपकी जगह काम करने वाला नहीं बन सकता।</p>
+    </header>
+
+    <section>
+      <h2>हुआ क्या</h2>
+      <p>आपके पास एक प्रोजेक्ट था। आपने PDF किसी AI टूल में डाली, उससे शोध-पत्र लिखवाया, और बिना पढ़े जवाब जमा कर
+        दिया। काम तेज़ी से हो गया। और साफ़-साफ़ दिख भी गया।</p>
+      <p>आपने असाइनमेंट पूरा नहीं किया। आपने <strong>अपने दिमाग़ का काम किसी और को सौंप दिया</strong> और नतीजे पर
+        अपना नाम चिपका दिया। संदर्भ तर्क से मेल नहीं खाते, तर्क आपकी अपनी आवाज़ जैसा नहीं लगता, और कभी-कभी जवाब पूरे
+        आत्मविश्वास के साथ ग़लत होता है। मुझे पता है। मैंने पढ़ा है।</p>
+      <p>काम AI ने किया। नंबर AI को मिलने चाहिए। <em>आपको नहीं।</em></p>
+    </section>
+
+    <div class="shout">
+      अपना दिमाग़ ठेके पर देना<br><span>सीखना</span> नहीं है।
+    </div>
+
+    <section>
+      <h2>इसके बजाय ये कीजिए</h2>
+      <ol>
+        <li>AI का इस्तेमाल रिसर्च के लिए कीजिए, आइडिया सोचने के लिए, कोई कठिन बात समझने के लिए, या दिशा तय करने के
+          लिए। उसे औज़ार की तरह इस्तेमाल कीजिए, अपनी राय के विकल्प की तरह नहीं।</li>
+        <li>वो जो कुछ दे, सब पढ़िए। स्रोत जाँचिए। जवाब पर सवाल उठाइए। मॉडल पूरे यक़ीन से बोलते हुए भी पूरी तरह ग़लत
+          हो सकते हैं, और नाम तो जमा किए गए काम पर आपका ही लगा होगा।</li>
+        <li>तर्क को अपना बनाइए। तय कीजिए कि आप क्या सोचते हैं, बताइए <em>क्यों</em>, और सबूत से उसे मज़बूत कीजिए।
+          असाइनमेंट आपकी सोच है, पैराग्राफ़ की गिनती नहीं।</li>
+        <li>तब तक एडिट कीजिए जब तक हर वाक्य समझ न आ जाए। अगर आप कोई बात चैटबॉट से दोबारा पूछे बिना समझा नहीं सकते, तो
+          आप उसे जमा करने के लिए तैयार नहीं हैं।</li>
+        <li>टूल के बारे में ईमानदार रहिए। AI के इस्तेमाल की घोषणा के नियम मानना भी काम ठीक से करने का हिस्सा है। एक
+          कच्चा लेकिन सचमुच आपका ड्राफ़्ट उस चमकदार जवाब से कहीं ज़्यादा क़ीमती है जिसे आपने कभी समझा ही नहीं।</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>ये AI-विरोधी नहीं है</h2>
+      <p>मैं आपसे ये नहीं कह रहा कि इन औज़ारों को अनदेखा कर दीजिए। इनसे बेहतर सवाल पूछिए, विरोधी तर्क ढूँढिए, किसी
+        विचार को परखिए, ड्राफ़्ट सुधारिए, और सीखिए। <strong>रिसर्च कीजिए। सोचिए। नियंत्रण रखिए। तर्क कीजिए। चुनौती
+          दीजिए।</strong></p>
+      <p>पर पूरा प्रोजेक्ट सौंपकर उसके आउटपुट को अपना काम मत कहिए। असाइनमेंट का मक़सद दस्तावेज़ जैसी कोई चीज़ तैयार
+        करना नहीं है। मक़सद ये है कि आप किसी बात को इतना समझ जाएँ कि उसे ख़ुद कह सकें।</p>
+    </section>
+
+    <section>
+      <h2>किसी को ये भेजना है?</h2>
+      <p>अगर किसी छात्र ने बिना पढ़े AI से लिखा शोध-पत्र जमा किया है, तो उसे ये लिंक भेजिए। शायद अगली बार वो अपना
+        दिमाग़ भी साथ लेकर आए।</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+          data-copy-aria="{domain} को क्लिपबोर्ड पर कॉपी करें" data-copy-path="/student/hi"
+          data-copied-text="कॉपी हो गया!">dontpastetheai.com/student</button></p>
+      <p class="u-center u-small u-muted u-mt-md">कॉपी करने के लिए क्लिक कीजिए।</p>
+    </section>
+
+    <section>
+      <h2>असली वाला पेज ढूँढ रहे हैं?</h2>
+      <p>मुख्य पेज उन सबके लिए है जो AI के जवाब बिना पढ़े ही चिपका देते हैं।</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" href="../">वापस "AI मत चिपकाइए" पर</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— सादर,<br>आपके निराश शिक्षक</div>
+      <small><a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> और
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a> का आध्यात्मिक चचेरा
+        भाई।<br>ध्यान से लिखा गया। भेजने से पहले प्रूफ़रीड भी किया गया।</small>
+    </div>
+
+    <div class="footer">
+      <p><em>अगर किसी ने आपको ये लिंक भेजा है: वो चाहता है कि आप इस पर ज़रा सोचें। पढ़िए, साँस लीजिए, और अगला वाक्य
+          ख़ुद लिखिए।</em></p>
+      <p>ये साइट व्यंग्य है (अगर आपका ध्यान न गया हो तो) — कॉपी कीजिए, बदलिए, अनुवाद कीजिए, बेझिझक।
+        <a href="https://github.com/khaosdoctor/dontquotetheai" target="_blank" rel="noopener">GitHub पर PR का स्वागत
+          है</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>

--- a/student/pa.html
+++ b/student/pa.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="pa" data-page="student">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ਕਿਰਪਾ ਕਰਕੇ AI ਜਮ੍ਹਾਂ ਨਾ ਕਰੋ।</title>
+  <meta name="description" content="AI ਤੁਹਾਡੇ ਖੋਜ-ਪੱਤਰ ਵਿੱਚ ਮਦਦ ਕਰ ਸਕਦਾ ਹੈ। ਉਹ ਤੁਹਾਡੇ ਵੱਲੋਂ ਸੋਚ ਨਹੀਂ ਸਕਦਾ।">
+  <meta property="og:title" content="ਕਿਰਪਾ ਕਰਕੇ AI ਜਮ੍ਹਾਂ ਨਾ ਕਰੋ।">
+  <meta property="og:description" content="AI ਤੁਹਾਡੇ ਖੋਜ-ਪੱਤਰ ਵਿੱਚ ਮਦਦ ਕਰ ਸਕਦਾ ਹੈ। ਉਹ ਤੁਹਾਡੇ ਵੱਲੋਂ ਸੋਚ ਨਹੀਂ ਸਕਦਾ।">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-pa.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="pa_IN">
+  <meta property="og:url" content="https://dontpastetheai.com/student/pa.html">
+  <link rel="canonical" href="https://dontpastetheai.com/student/pa.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image-pa.png">
+  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Noto+Serif+Gurmukhi:wght@400;700&family=Noto+Sans+Gurmukhi:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="../styles.css">
+  <style>
+    :root {
+      --font-type: "Noto Serif Gurmukhi", serif;
+      --font-mono: "Noto Sans Gurmukhi", sans-serif;
+    }
+  </style>
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/student/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/student/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/student/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/student/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/student/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/student/hu.html">
+  <link rel="alternate" hreflang="hy" href="https://dontpastetheai.com/student/hy.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/student/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/student/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/student/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/student/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/student/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/student/">
+  <!-- hreflang:end -->
+  <script src="../assets/translations.js" defer></script>
+  <script src="../assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>ਕੋਈ ਹੋਰ ਭਾਸ਼ਾ ਪਸੰਦ ਹੈ?</span>
+        <label class="lang" aria-label="ਭਾਸ਼ਾ">
+          <select data-lang-select>
+            <option>PA — ਪੰਜਾਬੀ</option>
+          </select>
+        </label>
+      </div>
+      <h1>ਕਿਰਪਾ ਕਰਕੇ <span class="yell">AI</span><br>ਜਮ੍ਹਾਂ ਨਾ ਕਰੋ।</h1>
+      <p class="lede">ਜਦੋਂ ਮੈਂ ਤੁਹਾਥੋਂ <em>ਤੁਹਾਡਾ</em> ਖੋਜ-ਪੱਤਰ ਮੰਗਦਾ ਹਾਂ, ਤਾਂ ਮੈਂ ਤੁਹਾਡੀ ਸੋਚ ਮੰਗ ਰਿਹਾ ਹੁੰਦਾ
+        ਹਾਂ। ਕਿਸੇ ਚੈਟਬੋਟ ਵਿੱਚ ਪਾਈ ਗਈ PDF ਦਾ ਜਵਾਬ ਵਾਪਸ ਚਿਪਕਾਇਆ ਹੋਇਆ ਨਹੀਂ। <span class="marker">AI ਤੁਹਾਡੇ ਕੰਮ ਵਿੱਚ
+          ਮਦਦ ਕਰ ਸਕਦਾ ਹੈ</span>। ਉਹ ਤੁਹਾਡੀ ਥਾਂ ਕੰਮ ਕਰਨ ਵਾਲਾ ਨਹੀਂ ਬਣ ਸਕਦਾ।</p>
+    </header>
+
+    <section>
+      <h2>ਹੋਇਆ ਕੀ</h2>
+      <p>ਤੁਹਾਡੇ ਕੋਲ ਇੱਕ ਪ੍ਰੋਜੈਕਟ ਸੀ। ਤੁਸੀਂ PDF ਕਿਸੇ AI ਟੂਲ ਵਿੱਚ ਪਾਈ, ਉਸ ਤੋਂ ਖੋਜ-ਪੱਤਰ ਲਿਖਵਾਇਆ, ਤੇ ਬਿਨਾਂ ਪੜ੍ਹੇ
+        ਜਵਾਬ ਜਮ੍ਹਾਂ ਕਰ ਦਿੱਤਾ। ਕੰਮ ਤੇਜ਼ੀ ਨਾਲ ਹੋ ਗਿਆ। ਤੇ ਸਾਫ਼-ਸਾਫ਼ ਦਿੱਸ ਵੀ ਗਿਆ।</p>
+      <p>ਤੁਸੀਂ ਅਸਾਈਨਮੈਂਟ ਪੂਰਾ ਨਹੀਂ ਕੀਤਾ। ਤੁਸੀਂ <strong>ਆਪਣੇ ਦਿਮਾਗ਼ ਦਾ ਕੰਮ ਕਿਸੇ ਹੋਰ ਨੂੰ ਸੌਂਪ ਦਿੱਤਾ</strong> ਤੇ
+        ਨਤੀਜੇ ਉੱਤੇ ਆਪਣਾ ਨਾਂ ਚਿਪਕਾ ਦਿੱਤਾ। ਹਵਾਲੇ ਦਲੀਲ ਨਾਲ ਮੇਲ ਨਹੀਂ ਖਾਂਦੇ, ਦਲੀਲ ਤੁਹਾਡੀ ਆਪਣੀ ਆਵਾਜ਼ ਵਰਗੀ ਨਹੀਂ
+        ਲੱਗਦੀ, ਤੇ ਕਦੇ-ਕਦੇ ਜਵਾਬ ਪੂਰੇ ਭਰੋਸੇ ਨਾਲ ਗ਼ਲਤ ਹੁੰਦਾ ਹੈ। ਮੈਨੂੰ ਪਤਾ ਹੈ। ਮੈਂ ਪੜ੍ਹਿਆ ਹੈ।</p>
+      <p>ਕੰਮ AI ਨੇ ਕੀਤਾ। ਨੰਬਰ AI ਨੂੰ ਮਿਲਣੇ ਚਾਹੀਦੇ ਨੇ। <em>ਤੁਹਾਨੂੰ ਨਹੀਂ।</em></p>
+    </section>
+
+    <div class="shout">
+      ਆਪਣਾ ਦਿਮਾਗ਼ ਠੇਕੇ 'ਤੇ ਦੇਣਾ<br><span>ਸਿੱਖਣਾ</span> ਨਹੀਂ ਹੈ।
+    </div>
+
+    <section>
+      <h2>ਇਸ ਦੀ ਥਾਂ ਇਹ ਕਰੋ</h2>
+      <ol>
+        <li>AI ਦੀ ਵਰਤੋਂ ਖੋਜ ਲਈ ਕਰੋ, ਵਿਚਾਰ ਲੱਭਣ ਲਈ, ਕੋਈ ਔਖੀ ਗੱਲ ਸਮਝਣ ਲਈ, ਜਾਂ ਦਿਸ਼ਾ ਤੈਅ ਕਰਨ ਲਈ। ਉਹਨੂੰ ਸੰਦ ਵਾਂਗ
+          ਵਰਤੋ, ਆਪਣੀ ਰਾਏ ਦੇ ਬਦਲ ਵਾਂਗ ਨਹੀਂ।</li>
+        <li>ਉਹ ਜੋ ਵੀ ਦੇਵੇ, ਸਭ ਪੜ੍ਹੋ। ਸਰੋਤ ਪਰਖੋ। ਜਵਾਬ ਉੱਤੇ ਸਵਾਲ ਚੁੱਕੋ। ਮਾਡਲ ਪੂਰੇ ਯਕੀਨ ਨਾਲ ਬੋਲਦੇ ਹੋਏ ਵੀ ਪੂਰੀ
+          ਤਰ੍ਹਾਂ ਗ਼ਲਤ ਹੋ ਸਕਦੇ ਨੇ, ਤੇ ਨਾਂ ਤਾਂ ਜਮ੍ਹਾਂ ਕੀਤੇ ਕੰਮ ਉੱਤੇ ਤੁਹਾਡਾ ਹੀ ਲੱਗਾ ਹੋਵੇਗਾ।</li>
+        <li>ਦਲੀਲ ਨੂੰ ਆਪਣਾ ਬਣਾਓ। ਤੈਅ ਕਰੋ ਕਿ ਤੁਸੀਂ ਕੀ ਸੋਚਦੇ ਹੋ, ਦੱਸੋ <em>ਕਿਉਂ</em>, ਤੇ ਸਬੂਤ ਨਾਲ ਉਹਨੂੰ ਮਜ਼ਬੂਤ ਕਰੋ।
+          ਅਸਾਈਨਮੈਂਟ ਤੁਹਾਡੀ ਸੋਚ ਹੈ, ਪੈਰ੍ਹਿਆਂ ਦੀ ਗਿਣਤੀ ਨਹੀਂ।</li>
+        <li>ਉਦੋਂ ਤੱਕ ਐਡਿਟ ਕਰੋ ਜਦੋਂ ਤੱਕ ਹਰ ਵਾਕ ਸਮਝ ਨਾ ਆ ਜਾਵੇ। ਜੇ ਤੁਸੀਂ ਕੋਈ ਗੱਲ ਚੈਟਬੋਟ ਤੋਂ ਦੁਬਾਰਾ ਪੁੱਛੇ ਬਿਨਾਂ
+          ਸਮਝਾ ਨਹੀਂ ਸਕਦੇ, ਤਾਂ ਤੁਸੀਂ ਉਹਨੂੰ ਜਮ੍ਹਾਂ ਕਰਨ ਲਈ ਤਿਆਰ ਨਹੀਂ ਹੋ।</li>
+        <li>ਟੂਲ ਬਾਰੇ ਇਮਾਨਦਾਰ ਰਹੋ। AI ਦੀ ਵਰਤੋਂ ਦੱਸਣ ਦੇ ਨਿਯਮ ਮੰਨਣਾ ਵੀ ਕੰਮ ਠੀਕ ਢੰਗ ਨਾਲ ਕਰਨ ਦਾ ਹਿੱਸਾ ਹੈ। ਇੱਕ ਕੱਚਾ
+          ਪਰ ਸੱਚਮੁੱਚ ਤੁਹਾਡਾ ਡਰਾਫ਼ਟ ਉਸ ਚਮਕਦਾਰ ਜਵਾਬ ਨਾਲੋਂ ਕਿਤੇ ਵੱਧ ਕੀਮਤੀ ਹੈ ਜਿਹਨੂੰ ਤੁਸੀਂ ਕਦੇ ਸਮਝਿਆ ਹੀ ਨਹੀਂ।</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>ਇਹ AI-ਵਿਰੋਧੀ ਨਹੀਂ ਹੈ</h2>
+      <p>ਮੈਂ ਤੁਹਾਨੂੰ ਇਹ ਨਹੀਂ ਕਹਿ ਰਿਹਾ ਕਿ ਇਹਨਾਂ ਸੰਦਾਂ ਨੂੰ ਅਣਦੇਖਿਆ ਕਰ ਦਿਓ। ਇਹਨਾਂ ਤੋਂ ਬਿਹਤਰ ਸਵਾਲ ਪੁੱਛੋ, ਵਿਰੋਧੀ
+        ਦਲੀਲਾਂ ਲੱਭੋ, ਕਿਸੇ ਵਿਚਾਰ ਨੂੰ ਪਰਖੋ, ਡਰਾਫ਼ਟ ਸੁਧਾਰੋ, ਤੇ ਸਿੱਖੋ। <strong>ਖੋਜ ਕਰੋ। ਸੋਚੋ। ਕੰਟਰੋਲ ਰੱਖੋ। ਦਲੀਲ
+          ਦਿਓ। ਚੁਣੌਤੀ ਦਿਓ।</strong></p>
+      <p>ਪਰ ਪੂਰਾ ਪ੍ਰੋਜੈਕਟ ਸੌਂਪ ਕੇ ਉਹਦੇ ਆਉਟਪੁੱਟ ਨੂੰ ਆਪਣਾ ਕੰਮ ਨਾ ਕਹੋ। ਅਸਾਈਨਮੈਂਟ ਦਾ ਮਕਸਦ ਦਸਤਾਵੇਜ਼ ਵਰਗੀ ਕੋਈ ਚੀਜ਼
+        ਤਿਆਰ ਕਰਨਾ ਨਹੀਂ ਹੈ। ਮਕਸਦ ਇਹ ਹੈ ਕਿ ਤੁਸੀਂ ਕਿਸੇ ਗੱਲ ਨੂੰ ਏਨਾ ਸਮਝ ਜਾਵੋ ਕਿ ਉਹਨੂੰ ਆਪ ਕਹਿ ਸਕੋ।</p>
+    </section>
+
+    <section>
+      <h2>ਕਿਸੇ ਨੂੰ ਇਹ ਭੇਜਣਾ ਹੈ?</h2>
+      <p>ਜੇ ਕਿਸੇ ਵਿਦਿਆਰਥੀ ਨੇ ਬਿਨਾਂ ਪੜ੍ਹੇ AI ਤੋਂ ਲਿਖਵਾਇਆ ਖੋਜ-ਪੱਤਰ ਜਮ੍ਹਾਂ ਕੀਤਾ ਹੈ, ਤਾਂ ਉਹਨੂੰ ਇਹ ਲਿੰਕ ਭੇਜੋ। ਸ਼ਾਇਦ
+        ਅਗਲੀ ਵਾਰ ਉਹ ਆਪਣਾ ਦਿਮਾਗ਼ ਵੀ ਨਾਲ ਲੈ ਕੇ ਆਵੇ।</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+          data-copy-aria="{domain} ਨੂੰ ਕਲਿੱਪਬੋਰਡ ਉੱਤੇ ਕਾਪੀ ਕਰੋ" data-copy-path="/student/pa"
+          data-copied-text="ਕਾਪੀ ਹੋ ਗਿਆ!">dontpastetheai.com/student</button></p>
+      <p class="u-center u-small u-muted u-mt-md">ਕਾਪੀ ਕਰਨ ਲਈ ਕਲਿੱਕ ਕਰੋ।</p>
+    </section>
+
+    <section>
+      <h2>ਅਸਲੀ ਵਾਲਾ ਪੰਨਾ ਲੱਭ ਰਹੇ ਹੋ?</h2>
+      <p>ਮੁੱਖ ਪੰਨਾ ਉਹਨਾਂ ਸਾਰਿਆਂ ਲਈ ਹੈ ਜੋ AI ਦੇ ਜਵਾਬ ਬਿਨਾਂ ਪੜ੍ਹੇ ਹੀ ਚਿਪਕਾ ਦਿੰਦੇ ਨੇ।</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" href="../">ਵਾਪਸ "AI ਨਾ ਚਿਪਕਾਓ" ਉੱਤੇ</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— ਸਤਿਕਾਰ ਸਹਿਤ,<br>ਤੁਹਾਡਾ ਨਿਰਾਸ਼ ਅਧਿਆਪਕ</div>
+      <small><a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> ਤੇ
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a> ਦਾ ਰੂਹਾਨੀ ਚਚੇਰਾ
+        ਭਰਾ।<br>ਧਿਆਨ ਨਾਲ ਲਿਖਿਆ ਗਿਆ। ਭੇਜਣ ਤੋਂ ਪਹਿਲਾਂ ਪਰੂਫ਼ਰੀਡ ਵੀ ਕੀਤਾ ਗਿਆ।</small>
+    </div>
+
+    <div class="footer">
+      <p><em>ਜੇ ਕਿਸੇ ਨੇ ਤੁਹਾਨੂੰ ਇਹ ਲਿੰਕ ਭੇਜਿਆ ਹੈ: ਉਹ ਚਾਹੁੰਦਾ ਹੈ ਕਿ ਤੁਸੀਂ ਇਸ ਬਾਰੇ ਜ਼ਰਾ ਸੋਚੋ। ਪੜ੍ਹੋ, ਸਾਹ ਲਵੋ, ਤੇ
+          ਅਗਲਾ ਵਾਕ ਆਪ ਲਿਖੋ।</em></p>
+      <p>ਇਹ ਸਾਈਟ ਵਿਅੰਗ ਹੈ (ਜੇ ਤੁਹਾਡਾ ਧਿਆਨ ਨਾ ਗਿਆ ਹੋਵੇ ਤਾਂ) — ਕਾਪੀ ਕਰੋ, ਬਦਲੋ, ਅਨੁਵਾਦ ਕਰੋ, ਬੇਝਿਜਕ।
+        <a href="https://github.com/khaosdoctor/dontquotetheai" target="_blank" rel="noopener">GitHub ਉੱਤੇ PR ਦਾ
+          ਸਵਾਗਤ ਹੈ</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>


### PR DESCRIPTION
## Translation PR

**Language codes (BCP 47, lowercase):** `hi`, `pa`

Adds Hindi (हिन्दी) and Punjabi (ਪੰਜਾਬੀ), each across all three pages: smooth, angry, and the student page.

Please confirm:

- [x] I translated **both** the smooth version (`<code>.html`) **and** the angry version (`angry/<code>.html`) for both languages. Also did `student/<code>.html` for both.
- [x] I added entries to `assets/translations.json` (under `languages` and under `pages.student`, kept sorted by `code`).
- [x] I left the `<!-- hreflang:start -->` / `<!-- hreflang:end -->` blocks alone — CI regenerates them on merge, per `TRANSLATING.md`.
- [x] My files have the correct `<html lang="...">`, `<link rel="canonical">`, `<meta property="og:url">`, and `<meta name="twitter:image">` pointing at `https://dontpastetheai.com/...`.
- [x] I created `assets/og-image-hi.svg` and `assets/og-image-pa.svg` (SVG only — PNGs are rendered by CI on merge).
- [x] I updated the no-JS fallback `<option>` inside `<select data-lang-select>` (`HI — हिन्दी`, `PA — ਪੰਜਾਬੀ`).
- [ ] The **Validate translations** GitHub Action passed on this PR.

**Notes / caveats:**

### Fonts

`Special Elite` covers neither script, so each set of pages overrides `--font-type` / `--font-mono` in a page-local `<style>` block. `styles.css` is untouched.

| | display (`--font-type`) | body (`--font-mono`) |
|---|---|---|
| `hi` | Kalam | Noto Sans Devanagari |
| `pa` | Noto Serif Gurmukhi | Noto Sans Gurmukhi |

Hindi reuses exactly the pair the Nepali pages already use, so CI already has the font it needs for that OG render. Gurmukhi has no hand-lettered face on Google Fonts with the right feel, so the Punjabi display type is a serif — it reads as a printed sheet rather than a typewritten one. Not identical to the English, but the same vibe.

### One non-translation change: `sync.yml`

`.github/workflows/sync.yml` installs a font per non-Latin script before `build-og-images.mjs` runs, and there was no Gurmukhi one — `og-image-pa.png` would have rendered as tofu on merge. I added one line next to the existing Devanagari/Armenian fetches:

```
curl -fsSL "https://cdn.jsdelivr.net/fontsource/fonts/noto-sans-gurmukhi@latest/gurmukhi-400-normal.ttf" -o ~/.local/share/fonts/noto-sans-gurmukhi.ttf || true
```

I verified that URL returns 200. Happy to drop this commit if you would rather handle the font install yourself.

### Translation choices

- **"AI" stays Latin** in both languages rather than being transliterated (`एआई` / `ਏਆਈ`). It is how Hindi and Punjabi tech writing overwhelmingly render it, and it keeps the red `.yell` / `<tspan>` word recognisable in the OG card.
- **Tone.** Smooth uses the polite register (`आप` / `ਤੁਸੀਂ`) and stays work-safe. Angry drops to the familiar (`तुम` / `ਤੂੰ`) and gets appropriately rude, with the swear censored the same way the English `f*cking` is.

### Local checks

`node scripts/check-translations.mjs` → **0 errors**, 8 warnings, all of them the expected "og-image-`<code>`.png missing, SVG source exists, CI renders it on merge".

Rendered all six pages against a local server: fonts load, no tofu, no horizontal overflow, the language dropdown picks up both new entries, and the smooth↔angry↔student cross-links resolve to the right per-language files.
