### PR TITLE
feat: add Estonian (et) translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Spiritual cousin of [nohello.net](https://nohello.net) and [dontasktoask.com](ht
 | فارسی (`fa`) | ✅ [fa.html](fa.html) | ✅ [angry/fa.html](angry/fa.html) | ✅ | [@am2mcu] |
 | Հայերեն (`hy`) | ✅ [hy.html](hy.html) | ✅ [angry/hy.html](angry/hy.html) | ✅ | [@vvahans] |
 | Română (`ro`) | ✅ [ro.html](ro.html) | ✅ [angry/ro.html](angry/ro.html) | ✅ | [@dorneanu] |
+| Eesti (`et`) | ✅ [et.html](et.html) | ✅ [angry/et.html](angry/et.html) | ✅ | [@jaxhend] |
 
 [@webknjaz]: https://github.com/sponsors/webknjaz
 [@alexeev-prog]: https://github.com/alexeev-prog
@@ -59,6 +60,7 @@ Spiritual cousin of [nohello.net](https://nohello.net) and [dontasktoask.com](ht
 [@dorneanu]: https://github.com/dorneanu
 [@ymaldor1]: https://github.com/ymaldor1
 [@vvahans]: https://github.com/vvahans
+[@jaxhend]: https://github.com/jaxhend
 
 Want to suggest a language? Open an issue or just send the PR (even a half-finished one). We can iterate. Huge thanks to everyone in the Maintainer column above who took the time to make this page work in their language.
 
@@ -71,6 +73,7 @@ A teacher-facing page at `/student/` for students who hand in AI-generated work 
 | Deutsch (`de`) | ✅ [`/student/de`](student/de.html) | Machine Translated |
 | English (`en`) | ✅ [`/student/`](student/index.html) | [@ymaldor1] |
 | Español (`es`) | ✅ [`/student/es`](student/es.html) | Machine Translated |
+| Eesti (`et`) | ✅ [`/student/et`](student/et.html) | [@jaxhend] |
 | فارسی (`fa`) | ✅ [`/student/fa`](student/fa.html) | Machine Translated |
 | Français (`fr`) | ✅ [`/student/fr`](student/fr.html) | [@ymaldor1] |
 | Magyar (`hu`) | ✅ [`/student/hu`](student/hu.html) | Machine Translated |

--- a/angry/et.html
+++ b/angry/et.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="et">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ära kleebi mulle enam AI-d.</title>
+  <meta name="description" content="Kui su vastus on hunnik LLM-i sitta, siis probleem oled sina.">
+  <meta property="og:title" content="Ära saada AI teksti">
+  <meta property="og:description" content="Kui su vastus on hunnik LLM-i sitta, siis probleem oled sina.">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-et.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="et_EE">
+  <meta property="og:url" content="https://dontpastetheai.com/angry/et.html">
+  <link rel="canonical" href="https://dontpastetheai.com/angry/et.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image-et.png">
+  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Special+Elite&family=JetBrains+Mono:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="../styles.css">
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/angry/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/angry/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/angry/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/angry/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/angry/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/angry/hu.html">
+  <link rel="alternate" hreflang="hy" href="https://dontpastetheai.com/angry/hy.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/angry/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/angry/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/angry/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/angry/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/angry/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/angry/">
+  <!-- hreflang:end -->
+  <script src="../assets/translations.js" defer></script>
+  <script src="../assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>Lase end omas keeles läbi võtta:</span>
+        <label class="lang" aria-label="Keel">
+          <select data-lang-select>
+            <option>ET — Eesti</option>
+          </select>
+        </label>
+      </div>
+      <h1>T*ra ära saada<br>seda <span class="yell">AI</span> vastust.</h1>
+      <p class="lede">Kui su vastus algab sõnadega <span class="marker">„Vaata, mida Claude ütles:"</span> või sa
+        commitid <span class="marker">kaheksasada sõna ChatGPT genereeritud teksti</span>, siis palju õnne: sa just
+        tõestasid, et su aju on ainult dekoratsioon. Darwin oleks uhke sinu üle. <strong>Palun ära paljune</strong>.
+      </p>
+    </header>
+
+    <section>
+      <h2>Mida sa just tegid:</h2>
+      <p>Keegi küsis sinult päris küsimuse. TÕELISE küsimuse. Tal oli kontekst ja parimad kavatsused. Ta tuli
+        <em>just sinu</em> juurde (milline au). Siis võtsid sa küsimuse, viskasid selle promptikasti ja kleepisid
+        tulemuse tagasi. Küllap tundsid end super produktiivse ja targana ja kõik... Kahju öelda, aga targemaks sa
+        ei saanud. Sa lihtsalt tõestasid, et sinult küsimisel ja AI-lt küsimisel pole mingit vahet.
+      </p>
+
+      <p><em>Arva ära, keda AI esimesena asendab?</em></p>
+
+      <blockquote>
+        <span class="exhibit-label">Juhuks kui see selge polnud, siis siin on see, mida sa vastasid:</span>
+        Suurepärane küsimus! Sellele nüansirikkale teemale, mille üle keegi päriselt vaevus mõtlema, lähenedes tuleb
+        arvestada mitme olulise teguriga. Võtame selle samm-sammult ette. Jälle:<br><br>
+        1. <strong>Konteksti mõistmine</strong> — Kõigepealt on oluline luua tugev alus, sest see on sõna-sõnalt see,
+        mida sa üldse küsisid<br>
+        2. <strong>Peamised kaalutlused</strong> — Seda hinnates tuleks meeles pidada, et... Olen kindel, et miski,
+        mida ma kohe ütlen, pole sul kordagi pähe tulnud<br>
+        3. <strong>Parimad praktikad</strong> — Valdkonna eksperdid soovitavad üldiselt seda Google'i otsingut, mille
+        sa oleksid ise 3 sekundiga ära teinud<br><br>
+
+        Kokkuvõtteks sõltub vastus lõppkokkuvõttes sinu konkreetsest olukorrast. Loodan, et see aitab, semu! Anna
+        teada, kui soovid, et ma mõnda neist punktidest täpsemalt lahti seletaksin.
+
+        <em>Vau... Valgustav. Uus Buddha kõnnib meie seas. Aitäh selle tarkusetera eest, mille ma oleksin ise kätte
+          saanud.</em>
+      </blockquote>
+    </section>
+
+    <section>
+      <h2>See on sügavalt lugupidamatu</h2>
+      <p>Inimesel, kellele sa vastasid, <strong>on sama AI mis sinul</strong>. Kui ta oleks tahtnud üldist LLM-i
+        vastust, oleks ta selle sekunditega kätte saanud ilma sinuga rääkimata, mis on muide <em>lihtsam</em>. Aga ta
+        küsis sinult, sest tahtis <em>sind</em>. Sinu arvamust. Sinu kogemust. Sinu maitset. Kõike seda, mida mudelil
+        pole.
+      </p>
+
+      <p>Selle asemel saatsid sa: <span class="marker">„Mul polnud kannatust su küsimust korralikult läbi lugeda ja
+          sellele päriselt vastata, nii et säh, robot ütles nii"</span>. See on vestluse mõistes sama mis
+        <strong>e-kirja edasi saatmine</strong>.
+      </p>
+
+      <p>Sa pole kellestki targem. Sa lihtsalt lased kellelgi reaalajas sinu suhtes lugupidamist kaotada, viisil,
+        mida on raske tagasi pöörata. Sa vahetasid oma arvamuse õnneküpsise lause vastu ja läksid oma eluga edasi.
+      </p>
+
+      <p>Kui sa niimoodi jätkad, siis <em>miks peaks keegi sinult üldse midagi küsima?</em></p>
+    </section>
+
+    <div class="shout">
+      Mudeli kleepimine<br>ei ole <span>mõtlemine</span>.
+    </div>
+
+    <section>
+      <h2>Lahendus on üsna lihtne</h2>
+      <ol>
+        <li>AI-d võib kasutada. See on hea tööriist. See on kasutamiseks olemas, aga meie ühise mõistuse nimel,
+          <strong>LOE</strong>, mida mudel ütles. Kõike. Jah, ka loetelusid, koodi, kogu seda värki...
+        </li>
+        <li>Otsusta, mis on kasulik ja mis mitte. Mudelid on enesekindlad viisil, millel pole õigusega mingit
+          pistmist. Pool sellest on tõenäoliselt vale, üldine või mõlemat. Ja seda siis, kui see pole otse
+          hallutsinatsioon.
+        </li>
+        <li>Kirjuta oma vastus. Kolm <em>sinu</em> lauset võidavad kolm lõiku läga iga kord. Keegi pole kunagi öelnud:
+          „Ooo, vennas... Oleks see vastus küll pikem ja robotlikum olnud".</li>
+        <li>Kui sul on päriselt vaja mudelit tsiteerida, olgu, seal on häid asju! Lihtsalt selgita, <em>miks</em>.
+          „Küsisin Claude'ilt ja see osa peab päriselt paika:", see on okei! Vähemalt sa lugesid läbi, mis seal toimus.
+          Sa meeldid meile ikka veel.
+        </li>
+        <li>Kui sul pole midagi lisada, <strong>ära ütle midagi</strong>. Vaikimine on ka panus. Või ütle „Mul pole
+          midagi lisada". See säästab kõigi aega.</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>„Aga ma tahan aidata!"</h2>
+      <p>Ei taha. Sa üritad <em>näida</em> abivalmis, ilma et teeksid abivalmis olemiseks tööd. Neil kahel on vahe.
+      </p>
+      <p>Aitamine on hoolikas <strong>lugemine</strong>, <strong>mõtlemine</strong> ja <strong>vastamine</strong>
+        millegagi, mida ainult sina oleksid saanud öelda, või vähemalt lihvida. AI-st kraami kleepimine ütleb
+        inimesele, et tema küsimus polnud sinu aega väärt, ainult vestlusroboti oma. Kuidas sina end tunneksid?
+      </p>
+    </section>
+
+    <section>
+      <h2>See leht ei ole AI vastu.</h2>
+      <p>Kasuta tööriistu. Kasuta neid iga päev. Kasuta neid, et kiiremini mustandeid teha, loovam olla, rohkem
+        õppida, end ummikust välja aidata. Suurepärane. Selleks need olemas ongi. <strong>Väljund on lähtepunkt,
+          mitte valmis töö.</strong> Kohtle seda nagu juuniorpraktikandi esimest mustandit, sest täpselt see see
+        ongi. Toimeta seda. Lõika seda. Vaidle sellele vastu. Tee see enda omaks või ära saada.
+      </p>
+    </section>
+
+    <section>
+      <h2>Kuidas seda kasutada?</h2>
+      <p>Järgmine kord, kui keegi paiskab sinu erasõnumitesse, Slacki, koodiülevaatusse, ausalt öeldes ükskõik kuhu
+        seinatäie toimetamata LLM-i teksti, saada talle see:</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" data-copy-path="/angry/et" type="button" class="url-tag-big"
+          data-copy-aria="Kopeeri {domain} lõikelauale" data-copied-text="kopeeritud!">dontpastetheai.com</button></p>
+      <p class="u-center u-small u-muted u-mt-md">Klõpsa kopeerimiseks.</p>
+    </section>
+
+    <section>
+      <h2>Liiga karm?</h2>
+      <p>Pole hullu. Saadaksid pigem kontorikõlbliku versiooni? See on ka olemas:</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" data-variant-toggle href="../">← Olen kapitalismi
+          ori</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— siiralt,<br> ilmselt kõik</div>
+      <small>vaimne nõbu lehtedele <a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> &amp;
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a>.<br>selle lehe
+        kirjutas <a href="https://github.com/khaosdoctor/dontquotetheai/issues/31" target="_blank" rel="noopener">üks suvaline tüüp</a> (pöörane, eks?). Ja luges päriselt ka üle.
+      </small>
+    </div>
+
+    <div class="footer">
+      <p><em>Kui keegi saatis sulle selle lingi, ära ole tema peale <a href="https://www.youtube.com/watch?v=xzpndHtdl9A"
+            target="_blank" rel="noopener">vihane</a>. Ta tuli heade kavatsustega. Loe see läbi, hinga ja kirjuta oma
+          järgmine vastus ise.</em></p>
+      <p>Satiir (juhuks kui märkamata jäi). Jaga, muuda ja tõlgi vabalt —
+        <a href="https://github.com/khaosdoctor/dontpastetheai" target="_blank" rel="noopener">PR-id on GitHubis
+          teretulnud</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>

--- a/assets/og-image-et.svg
+++ b/assets/og-image-et.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <rect width="1200" height="630" fill="#ede2c4"/>
+
+  <ellipse cx="1020" cy="95" rx="400" ry="300" fill="#5a3214" opacity="0.08"/>
+  <ellipse cx="120" cy="565" rx="300" ry="200" fill="#5a3214" opacity="0.05"/>
+
+  <text x="600" y="230" text-anchor="middle" font-family="Special Elite" font-size="100" fill="#15120e">Oih, sa kleepisid</text>
+  <text x="600" y="340" text-anchor="middle" font-family="Special Elite" font-size="100" fill="#15120e"><tspan fill="#a82820">AI</tspan>-d ilma seda</text>
+  <text x="600" y="450" text-anchor="middle" font-family="Special Elite" font-size="100" fill="#15120e">läbi lugemata.</text>
+
+  <g transform="translate(740,540) rotate(-1)">
+    <rect x="4" y="4" width="380" height="60" fill="#15120e"/>
+    <rect x="0" y="0" width="380" height="60" fill="#f5d547" stroke="#15120e" stroke-width="3"/>
+    <text x="190" y="44" text-anchor="middle" font-family="Special Elite" font-size="32" fill="#15120e">dontpastetheai.com</text>
+  </g>
+</svg>

--- a/assets/translations.json
+++ b/assets/translations.json
@@ -22,6 +22,13 @@
       "file": "es.html"
     },
     {
+      "code": "et",
+      "hreflang": "et",
+      "locale": "et_EE",
+      "label": "ET — Eesti",
+      "file": "et.html"
+    },
+    {
       "code": "fa",
       "hreflang": "fa",
       "locale": "fa_IR",
@@ -177,6 +184,13 @@
         "locale": "es_ES",
         "label": "ES — Español",
         "file": "es.html"
+      },
+      {
+        "code": "et",
+        "hreflang": "et",
+        "locale": "et_EE",
+        "label": "ET — Eesti",
+        "file": "et.html"
       },
       {
         "code": "fa",

--- a/et.html
+++ b/et.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="et">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ära saada AI teksti, palun.</title>
+  <meta name="description" content="Kui keegi sinult midagi küsib, saada oma vastus. Mitte AI oma.">
+  <meta property="og:title" content="Ära saada AI teksti, palun.">
+  <meta property="og:description" content="Kui keegi sinult midagi küsib, saada oma vastus. Mitte AI oma.">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-et.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="et_EE">
+  <meta property="og:url" content="https://dontpastetheai.com/et.html">
+  <link rel="canonical" href="https://dontpastetheai.com/et.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image-et.png">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Special+Elite&family=JetBrains+Mono:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/hu.html">
+  <link rel="alternate" hreflang="hy" href="https://dontpastetheai.com/hy.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/">
+  <!-- hreflang:end -->
+  <script src="assets/translations.js" defer></script>
+  <script src="assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>Eelistad teist keelt?</span>
+        <label class="lang" aria-label="Keel">
+          <select data-lang-select>
+            <option>ET — Eesti</option>
+          </select>
+        </label>
+      </div>
+      <h1>Ära saada<br><span class="yell">AI</span> teksti, palun.</h1>
+      <p class="lede">Kui keegi Sinult midagi küsib, tahab ta <em>sinu</em> vastust.
+        Mitte tervet lehekülge <span class="marker">ChatGPT teksti</span>. Lühike vastus inimeselt on alati rohkem
+        väärt kui pikk vastus robotilt, isegi kui robotil on õigus.</p>
+    </header>
+
+    <section>
+      <h2>Mis juhtus</h2>
+      <p>Keegi küsis sinult raske küsimuse. Sina viskasid selle vestlusrobotisse, kopeerisid vastuse ja saatsid tagasi.
+        Tundus kiire. Tundus abivalmis. Tegelt ei olnud.</p>
+      <p>Võib-olla sulle ei tundu nii, aga vestluse teisel poolel <strong>on täpselt samad tööriistad mis sinul</strong>. Kui ta
+        oleks tahtnud üldist vastust, oleks ta selle paari sekundiga ise kätte saanud. Ta küsis <em>sinult</em>, sest
+        tahtis sinu arvamust... Sinu konteksti, sinu ideid, sinu hinnangut.</p>
+
+      <p>Maailm on täis inimesi, kes ei viitsi lugeda ega asju läbi mõelda. Ära ole üks neist.</p>
+    </section>
+
+    <section>
+      <h2>Tee hoopis nii</h2>
+      <ol>
+        <li>AI-d võib kasutada. Päriselt! See on mustandite jaoks suurepärane tööriist. Lihtsalt <strong>loe läbi,
+            mis ta sulle andis</strong>, ja kirjuta siis oma versioon või lihvi teksti. Ära ole vahendaja tema ja
+          vastuse vahel.</li>
+        <li>Võta see osa, mis päriselt küsimusele vastab, ja jäta ülejäänu kõrvale. Kolmest lausest piisab, ja isegi
+          kui need on kopeeritud, oled sa need vähemalt läbi lugenud.</li>
+        <li>Kui mõni osa mudeli vastusest on päriselt kasulik, tsiteeri seda ja selgita, <em>miks</em>.
+          <span class="marker"><em>„Küsisin Claude'ilt ja see koht siin on loogiline:"</em></span>.
+        </li>
+        <li>Kui sul pole midagi lisada, ütle seda. <span class="marker"><em>„Mul pole siin tugevat
+              arvamust."</em></span> Vaikimine on ka variant.
+        </li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>Tahad seda kellelegi saata?</h2>
+      <p>Kui keegi just paiskas sinu sõnumitesse, Slacki või koodiülevaatusse seinatäie LLM-i teksti, võid talle
+        selle lingi saata.</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+          data-copy-aria="Kopeeri {domain} lõikelauale" data-copied-text="kopeeritud!">dontpastetheai.com</button></p>
+      <p class="u-center u-small u-muted u-mt-md">Klõpsa kopeerimiseks.</p>
+    </section>
+
+    <section>
+      <h2>Tahad karmimat versiooni?</h2>
+      <p>Kui saadaksid pigem versiooni, kus on <em>rohkem vürtsi</em>, siis see on olemas!</p>
+      <p class="u-center u-mt-lg"><a class="cta-angry" data-variant-toggle href="angry/index.html">Tahan sildu
+          põletada 🔥</a></p>
+      <p class="u-center u-small u-muted u-mt-md">Tööl ei pruugi see eriti hästi peale minna, aga sinu otsus</p>
+    </section>
+
+    <section>
+      <h2>Oled õpetaja?</h2>
+      <p>Kui su õpilased saadavad sulle AI genereeritud essee või projekti, võid neile saata selle lingi:</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" data-student-toggle href="student/">Saada nad tundi</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— lugupidamisega... vist?<br>Kõik</div>
+      <small>vaimne nõbu lehtedele <a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> &amp;
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a>.<br>kirjutas
+        üks suvaline tüüp (<a href="https://github.com/khaosdoctor/dontquotetheai/issues/31" target="_blank" rel="noopener">usu või mitte</a>). Täpselt nagu vanasti.</small>
+    </div>
+
+    <div class="footer">
+      <p><em>Kui keegi saatis sulle selle lingi: ta tahab, et sa selle üle mõtleksid. Loe, hinga ja kirjuta järgmine
+          vastus ise.</em></p>
+      <p>See leht on satiir (juhuks kui sa ei märganud) — kopeeri, muuda, tõlgi ja nii edasi, julgelt.
+        <a href="https://github.com/khaosdoctor/dontquotetheai" target="_blank" rel="noopener">PR-id on GitHubis
+          teretulnud</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>

--- a/student/et.html
+++ b/student/et.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="et" data-page="student">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ära esita AI teksti, palun.</title>
+  <meta name="description" content="AI võib su esseega aidata. Sinu eest mõelda ta ei saa.">
+  <meta property="og:title" content="Ära esita AI teksti, palun.">
+  <meta property="og:description" content="AI võib su esseega aidata. Sinu eest mõelda ta ei saa.">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-et.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="et_EE">
+  <meta property="og:url" content="https://dontpastetheai.com/student/et.html">
+  <link rel="canonical" href="https://dontpastetheai.com/student/et.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image-et.png">
+  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Special+Elite&family=JetBrains+Mono:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="../styles.css">
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/student/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/student/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/student/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/student/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/student/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/student/hu.html">
+  <link rel="alternate" hreflang="hy" href="https://dontpastetheai.com/student/hy.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/student/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/student/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/student/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/student/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/student/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/student/">
+  <!-- hreflang:end -->
+  <script src="../assets/translations.js" defer></script>
+  <script src="../assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>Eelistad teist keelt?</span>
+        <label class="lang" aria-label="Keel">
+          <select data-lang-select>
+            <option>ET — Eesti</option>
+          </select>
+        </label>
+      </div>
+      <h1>Ära esita<br><span class="yell">AI</span> teksti, palun.</h1>
+      <p class="lede">Kui ma küsin sinult <em>sinu</em> esseed, küsin ma sinu mõtlemist.
+        Mitte PDF-i, mis on vestlusrobotile söödetud ja mulle tagasi kleebitud. <span class="marker">AI võib sind
+          töös aidata</span>. Ta ei saa olla see, kes töö ära teeb.</p>
+    </header>
+
+    <section>
+      <h2>Mis juhtus</h2>
+      <p>Sul oli projekt. Sa viskasid PDF-i AI tööriista, palusid tal essee kirjutada ja esitasid vastuse ilma seda
+        lugemata. See oli efektiivne. See oli ka äärmiselt ilmne.</p>
+      <p>Sa ei teinud ülesannet ära. Sa <strong>delegeerisid oma ajutegevuse</strong> ja panid tulemusele oma nime
+        alla. Viited ei klapi argumendiga, argument ei kõla sinu moodi ja kohati on vastus enesekindlalt vale. Ma
+        tean. Ma lugesin seda.</p>
+      <p>AI tegi töö. AI saab hinde. <em>Sina mitte.</em></p>
+    </section>
+
+    <div class="shout">
+      Aju allhange<br>ei ole <span>õppimine</span>.
+    </div>
+
+    <section>
+      <h2>Tee hoopis nii</h2>
+      <ol>
+        <li>Kasuta AI-d uurimiseks, ideede genereerimiseks, keerulise mõiste selgitamiseks või suuna leidmiseks. Kasuta
+          seda tööriistana, mitte oma seisukoha asendajana.</li>
+        <li>Loe läbi kõik, mis ta sulle annab. Kontrolli allikaid. Sea vastus kahtluse alla. Mudelid võivad kõlada
+          kindlalt, olles samas täiesti valed, ja esitatud töö peal on ikka sinu nimi.</li>
+        <li>Tee argument enda omaks. Otsusta, mida sa arvad, selgita, <em>miks</em>, ja toeta seda tõenditega.
+          Ülesanne on sinu arutluskäik, mitte lõikude arv.</li>
+        <li>Toimeta, kuni mõistad iga lauset. Kui sa ei suuda väidet selgitada ilma vestlusrobotilt uuesti küsimata,
+          pole sa valmis seda esitama.</li>
+        <li>Ole tööriista osas aus. AI kasutamise deklareerimise reeglite järgimine on osa töö korralikult tegemisest.
+          Konarlik, aga päriselt sinu oma mustand on rohkem väärt kui lihvitud vastus, mida sa kunagi ei mõistnud.</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>See ei ole AI vastu</h2>
+      <p>Ma ei palu sul teeselda, et neid tööriistu pole olemas. Kasuta neid, et küsida paremaid küsimusi, leida
+        vastuargumente, testida ideed, parandada mustandit ja õppida. <strong>Uuri. Mõtle. Kontrolli. Argumenteeri.
+          Sea kahtluse alla.</strong></p>
+      <p>Aga ära lihtsalt anna projekti üle ja nimeta väljundit oma tööks. Ülesande mõte ei ole toota dokumendi kujuga
+        objekti. Mõte on, et sa mõistaksid midagi piisavalt hästi, et seda ise öelda.</p>
+    </section>
+
+    <section>
+      <h2>Tahad seda kellelegi saata?</h2>
+      <p>Kui õpilane esitas AI genereeritud essee ilma seda lugemata, saada talle see link. Ehk järgmine kord võtab
+        ta oma aju ka kaasa.</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+          data-copy-aria="Kopeeri {domain} lõikelauale" data-copy-path="/student/et"
+          data-copied-text="kopeeritud!">dontpastetheai.com/student</button></p>
+      <p class="u-center u-small u-muted u-mt-md">Klõpsa kopeerimiseks.</p>
+    </section>
+
+    <section>
+      <h2>Otsid originaali?</h2>
+      <p>Põhileht on kõigile, kes kleebivad AI vastuseid neid enne lugemata.</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" href="../">Tagasi lehele „Ära saada AI teksti"</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— siiralt,<br>sinu pettunud õpetaja</div>
+      <small>vaimne nõbu lehtedele <a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> &amp;
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a>.<br>Kirjutatud
+        hoolega. Enne saatmist üle loetud.</small>
+    </div>
+
+    <div class="footer">
+      <p><em>Kui keegi saatis sulle selle lingi: ta tahab, et sa selle üle mõtleksid. Loe, hinga ja kirjuta järgmine
+          lause ise.</em></p>
+      <p>See leht on satiir (juhuks kui sa ei märganud) — kopeeri, muuda, tõlgi ja nii edasi, julgelt.
+        <a href="https://github.com/khaosdoctor/dontquotetheai" target="_blank" rel="noopener">PR-id on GitHubis
+          teretulnud</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>


### PR DESCRIPTION
Adds Estonian (`et`) for all three pages, following TRANSLATING.md.

- `et.html`, `angry/et.html`, `student/et.html`
- `assets/og-image-et.svg` (Latin-only glyphs, renders fine with the fontsource Special Elite CI already installs)
- `et` registered under both `languages` and `pages.student` in `assets/translations.json`
- README rows for both tables

`node scripts/check-translations.mjs` passes with 0 errors, only the expected missing-PNG warnings. hreflang blocks untouched. Native speaker, proofread all three.