### PR TITLE
Add Turkmen (tk) translation

### DIFF
--- a/angry/de.html
+++ b/angry/de.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/es.html
+++ b/angry/es.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/fa.html
+++ b/angry/fa.html
@@ -71,6 +71,7 @@
     <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
     <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
     <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+    <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
     <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
     <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
     <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/fr.html
+++ b/angry/fr.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/hu.html
+++ b/angry/hu.html
@@ -47,6 +47,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/hy.html
+++ b/angry/hy.html
@@ -51,6 +51,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/id.html
+++ b/angry/id.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/index.html
+++ b/angry/index.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/it.html
+++ b/angry/it.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/ja.html
+++ b/angry/ja.html
@@ -51,6 +51,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/ko.html
+++ b/angry/ko.html
@@ -53,6 +53,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/ne.html
+++ b/angry/ne.html
@@ -51,6 +51,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/pl.html
+++ b/angry/pl.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/pt-br.html
+++ b/angry/pt-br.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/ro.html
+++ b/angry/ro.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/ru.html
+++ b/angry/ru.html
@@ -46,6 +46,7 @@
     <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
     <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
     <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+    <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
     <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
     <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
     <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/sr-latn.html
+++ b/angry/sr-latn.html
@@ -48,6 +48,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/sr.html
+++ b/angry/sr.html
@@ -48,6 +48,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/tk.html
+++ b/angry/tk.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="tk">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Maňa emeli aňyň jogabyny ýapyşdyrma.</title>
+  <meta name="description" content="Jogabyň redaktirlenmedik LLM galyndysy bolsa, mesele sende.">
+  <meta property="og:title" content="Emeli aňy ýapyşdyrma">
+  <meta property="og:description" content="Jogabyň redaktirlenmedik LLM galyndysy bolsa, mesele sende.">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-tk.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="tk_TM">
+  <meta property="og:url" content="https://dontpastetheai.com/angry/tk.html">
+  <link rel="canonical" href="https://dontpastetheai.com/angry/tk.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image-tk.png">
+  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Special+Elite&family=JetBrains+Mono:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="../styles.css">
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/angry/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/angry/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/angry/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/angry/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/angry/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/angry/hu.html">
+  <link rel="alternate" hreflang="hy" href="https://dontpastetheai.com/angry/hy.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/angry/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/angry/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/angry/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/angry/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/angry/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/angry/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/angry/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/angry/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/angry/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/angry/">
+  <!-- hreflang:end -->
+  <script src="../assets/translations.js" defer></script>
+  <script src="../assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>Öz diliňde azarlanmak isleseň:</span>
+        <label class="lang" aria-label="Dil">
+          <select data-lang-select>
+            <option>TK — Türkmençe</option>
+          </select>
+        </label>
+      </div>
+      <h1>Maňa şu <span class="yell">emeli aň</span><br>jogabyny ýapyşdyrmagy bes et.</h1>
+      <p class="lede">Jogabyň <span class="marker">"Seret, Claude näme diýdi:"</span> diýip başlaýan bolsa ýa-da
+        <span class="marker">redaktirlenmedik sekiz ýüz sözlü ChatGPT tekstini</span> ýapyşdyran bolsaň, gutlaýarys:
+        beýniň diňe bezeg üçindigini subut etdiň. Darwin seniň bilen buýsanardy.
+        <strong>Haýyş, köpelme</strong>.
+      </p>
+    </header>
+
+    <section>
+      <h2>Häzir eden işiň şu:</h2>
+      <p>Biri saňa hakyky sorag berdi, HAKYKY sorag. Niýeti arassa. Hususanda <em>saňa</em> ýüz tutdy
+        (nähili hormat). Sen bolsa soragy aldyň, buýruk penjiresine taşladyň we çykan netijäni yzyna ýapyşdyrdyň.
+        Örän ugur tapyjy we akylly duýduň, şeýlemi? Ýaman habar: has akylly bolmadyň, sen diňe saňa soramagyň bilen emeli
+        aňa soramagyň arasynda hiç hili tapawudyň ýokdugyny subut etdiň.
+      </p>
+
+      <p><em>Emeli aňyň ilki kimiň ýerini aljakydygyny pikir et?</em></p>
+
+      <blockquote>
+        <span class="exhibit-label">Düşnükli bolmadyk bolsa, beren jogabyň gysgaça şu:</span>
+        Ajaýyp sorag! Biri hakykatdan wagtyny we beýnisini sarp edip oýlan bu çylşyrymly mesele çemeleşende göz
+        öňünde tutmaly birnäçe ädim bar. Gel, ädim-ädim ýene bir gezek böleli:<br><br>
+        1. <strong>Ýagdaýa düşünmek</strong> — Ilki bilen berk esas goýmak möhüm, çünki sen aslynda hut şuny soradyň<br>
+        2. <strong>Esasy bellikler</strong> — Muna baha bereniňde, öň hiç haçan kelläňe-de gelmedik şu
+        bellikleri ýatda saklamaly<br>
+        3. <strong>Iň gowy tejribeler</strong> — Pudak hünärmenleri adatça üç sekuntda edip biljek şu ýönekeý Google
+        gözlegini maslahat berýär<br><br>
+
+        Netijede, jogap dolulygy seniň anyk ýagdaýyňa bagly. Peýdaly boldy diýip umyt edýärin, jigim! Şu maddalaryň
+        haýsy bolsa-da giňişleýin düşündirmegimi isleseň, habar ber.
+
+        <em>Wah...Ylham berdiň. Aramyzda bir Akyldar gezip ýör. Özümem tapyp biljek bu dana maslahat üçin sag bol.</em>
+      </blockquote>
+    </section>
+
+    <section>
+      <h2>Bu düýpgöter hormatsyzlyk</h2>
+      <p>Jogap beren adamyňda-da <strong>seniňki bilen birmeňzeş emeli aň bar</strong>. Oňa adaty LLM jogaby gerek
+        bolsa, saňa ýüz tutman dört sekuntda özi alardy, bu üstesine <em>aňsat hem</em>. Ýöne ol saňa sorady,
+        çünki <em>seniň pikriňi</em> isledi. Seniň pikiriňi. Tejribäňi. Logikaňy. Modelde bolmadyk her zady.
+      </p>
+
+      <p>Seniň ibereniň muňa meňzeýär: <span class="marker">"Soragyňy ünsli okamaga we jogap bermäge sabrym ýetmedi, al,
+          robot meniň ýerime şu zady aýtdy"</span>. Bu gürrüňdeşlikde <strong>e-poçtany şol durşy bilen başgasyna ugratmaga</strong>
+        deňdir.
+      </p>
+
+      <p>Sen hiç kimden akylly däl. Sen adamyň saňa bolan hormatyny ýitirmegine sebäp bolýäň, yzyna almak hem kyn. Öz pikiriň ýerine robot oýunjagyň setirini goýup, ýolyňy dowam etdiň.
+      </p>
+
+      <p>Şuny etmegä dowam etseň, <em>adamlar aslynda näme üçin saňa bir zat sorasyn?</em></p>
+    </section>
+
+    <div class="shout">
+      Modeliň jogabyny ýapyşdyrmak<br><span>pikirlenmek</span> däldir.
+    </div>
+
+    <section>
+      <h2>Çözgüdi gaty aňsat</h2>
+      <ol>
+        <li>Emeli aňy ulanyp bilersiň. Gowy gural. Ulanmak üçin bar, ýöne umumy akyl-saglygyň üçin,
+          modeliň aýdanyny <strong>OKA</strong>. Hemmesini. Hawa, sanawlary-da, kody-da, barsyny...
+        </li>
+        <li>Näme peýdaly, näme däl — karar ber. Modelleriň ynamly jogap bermegi, jogaplaryň dogrulygyny görkezmeýär.
+          Ýarysy ähtimal ýalňyş ýa-da adaty ýa-da ikisi-de. Bu heniz modeliň aç-açan göni galýusinasiýa (ýalňyş maglumat) bolmadyk wagty.
+        </li>
+        <li>Öz jogabyňy ýaz. <em>Özüňden</em> çykan üç sözlem, modeliň üç abzasyny ýeňer. Hiç kim hiç wagt:
+          "Bäý oglan... Käşke şu jogap has uzyn we robot ýaly bolsady" diýmändir.</li>
+        <li>Modelden hakykatdan sitata getirmeli bolsaň, bolýa, içinde gowy zatlar hem bar! Diňe <em>näme üçin</em>digini
+          düşündir. "Claudedan soradym, şu bölegi hakykatdan dogry:" — bolýar! Azyndan ýazylan zady okansyň, seni heniz hem
+          gowy görýäris
+        </li>
+        <li>Goşar ýaly zadyň ýok bolsa, <strong>hiç zat diýme</strong>. Dymmak hem uly goşant. Ýa-da "Goşar ýaly zadym ýok" diý.
+          Bu hemmeleriň wagtyny tygşytlar.</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>"Ýöne men kömek etmek isleýärin!"</h2>
+      <p>Ýok, islemeýärsiň. Sen kömek etmegiň zähmetini çekmän <em>kömekçi görünmäge</em> synanyşýarsyň. Arada tapawut
+        bar.
+      </p>
+      <p>Kömek etmek — ünsli <strong>okamak</strong>, <strong>pikirlenmek</strong> we diňe seniň aýdyp biljek zadyň bilen,
+        ýa azyndan redaktirläniň bilen <strong>jogap bermekdir</strong>. Emeli aňdan bir zat ýapyşdyrmak adama onuň
+        soragynyň seniň wagtyňa däl-de, diňe çetbotyň wagtyna degendigini aýdýar. Sen bolsaň näme duýardyň?
+      </p>
+    </section>
+
+    <section>
+      <h2>Bu sahypa emeli aňa garşy däl.</h2>
+      <p>Gurallary ulan. Her gün ulan. Çalt taslama üçin, has döredijilikli bolmak üçin, has köp öwrenmek üçin, dykylan
+        ýeriňden çykmak üçin ulan. Gowy. Olar şonuň üçin bar. <strong>Çykyş başlangyç nokat, tabşyryk däl.</strong> Muňa
+        tejribesiz stažýoryň ilkinji taslamasy ýaly çemeleş, çünki ol hut şonuň özi. Redaktirle. Kes. Garşy çyk. Özüňki
+        et, ýa-da iberme.
+      </p>
+    </section>
+
+    <section>
+      <h2>Muny nähili ulanmaly?</h2>
+      <p>Indiki gezek biri şahsy hatlaryňa, Slack-e, kod synyňa ýa-da islendik ýere redaktirlenmedik LLM tekstiniň uly
+        diwaryny taşlasa, oňa şuny iber:</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" data-copy-path="/angry/tk" type="button" class="url-tag-big"
+          data-copy-aria="{domain} adresini bukja göçür" data-copied-text="göçürildi!">dontpastetheai.com</button></p>
+      <p class="u-center u-small u-muted u-mt-md">Göçürmek üçin bas. Düşündiriş gerek däl, düşüner.</p>
+    </section>
+
+    <section>
+      <h2>Has agyrmy?</h2>
+      <p>Bolmagy mümkin. Iş ýerine amatly görnüşini ibermek isleseň, al:</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" data-variant-toggle href="../">← Men emeli aňyň guly</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— hormat bilen,<br>ähtimal hemmeler</div>
+      <small><a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> we
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a>-yň ruhy dogany.<br>bu sahypany
+        <a href="https://github.com/khaosdoctor/dontquotetheai/issues/31" target="_blank" rel="noopener">tötänleýin biri</a> ýazdy (geň, şeýlemi?). We hakykatdan gözden geçirildi.
+      </small>
+    </div>
+
+    <div class="footer">
+      <p><em>Biri saňa şu sahypany iberen bolsa, oňa <a href="https://www.youtube.com/watch?v=xzpndHtdl9A"
+            target="_blank" rel="noopener">gaharlanma</a>. Ol hoş niýet bilen geldi. Oka, dem al we indiki
+          jogabyňy özüň ýaz.</em></p>
+      <p>Satira (duýmadyk bolsaň). Paýlaşmak, üýtgetmek we terjime etmek erkin —
+        <a href="https://github.com/khaosdoctor/dontpastetheai" target="_blank" rel="noopener">GitHubda PRlara
+          açyk</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>

--- a/angry/tr.html
+++ b/angry/tr.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/uk.html
+++ b/angry/uk.html
@@ -48,6 +48,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/zh-cn.html
+++ b/angry/zh-cn.html
@@ -79,6 +79,7 @@
         <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
         <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
         <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+        <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
         <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
         <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
         <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/angry/zh-tw.html
+++ b/angry/zh-tw.html
@@ -48,6 +48,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/angry/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/angry/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/angry/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/angry/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/angry/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/angry/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/angry/zh-cn.html">

--- a/assets/og-image-tk.svg
+++ b/assets/og-image-tk.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <rect width="1200" height="630" fill="#ede2c4"/>
+
+  <ellipse cx="1020" cy="95" rx="400" ry="300" fill="#5a3214" opacity="0.08"/>
+  <ellipse cx="120" cy="565" rx="300" ry="200" fill="#5a3214" opacity="0.05"/>
+
+  <text x="600" y="230" text-anchor="middle" font-family="Special Elite" font-size="100" fill="#15120e">Wah, sen okamazdan</text>
+  <text x="600" y="340" text-anchor="middle" font-family="Special Elite" font-size="100" fill="#15120e"><tspan fill="#a82820">emeli aňy</tspan></text>
+  <text x="600" y="450" text-anchor="middle" font-family="Special Elite" font-size="100" fill="#15120e">ýapyşdyrdyň.</text>
+
+  <g transform="translate(740,540) rotate(-1)">
+    <rect x="4" y="4" width="380" height="60" fill="#15120e"/>
+    <rect x="0" y="0" width="380" height="60" fill="#f5d547" stroke="#15120e" stroke-width="3"/>
+    <text x="190" y="44" text-anchor="middle" font-family="Special Elite" font-size="32" fill="#15120e">dontpastetheai.com</text>
+  </g>
+</svg>

--- a/assets/translations.json
+++ b/assets/translations.json
@@ -127,6 +127,13 @@
       "file": "sr-latn.html"
     },
     {
+      "code": "tk",
+      "hreflang": "tk",
+      "locale": "tk_TM",
+      "label": "TK — Türkmençe",
+      "file": "tk.html"
+    },
+    {
       "code": "tr",
       "hreflang": "tr",
       "locale": "tr_TR",
@@ -282,6 +289,13 @@
         "locale": "sr_RS",
         "label": "SR — Srpski (lat.)",
         "file": "sr-latn.html"
+      },
+      {
+        "code": "tk",
+        "hreflang": "tk",
+        "locale": "tk_TM",
+        "label": "TK — Türkmençe",
+        "file": "tk.html"
       },
       {
         "code": "tr",

--- a/de.html
+++ b/de.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/es.html
+++ b/es.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/fa.html
+++ b/fa.html
@@ -72,6 +72,7 @@
     <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
     <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
     <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+    <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
     <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
     <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
     <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/fr.html
+++ b/fr.html
@@ -47,6 +47,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/hu.html
+++ b/hu.html
@@ -47,6 +47,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/hy.html
+++ b/hy.html
@@ -51,6 +51,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/id.html
+++ b/id.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/it.html
+++ b/it.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/ja.html
+++ b/ja.html
@@ -51,6 +51,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/ko.html
+++ b/ko.html
@@ -53,6 +53,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/ne.html
+++ b/ne.html
@@ -51,6 +51,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/pl.html
+++ b/pl.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/pt-br.html
+++ b/pt-br.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/ro.html
+++ b/ro.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/ru.html
+++ b/ru.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -110,6 +110,12 @@
     <loc>https://dontpastetheai.com/angry/sr-latn.html</loc>
   </url>
   <url>
+    <loc>https://dontpastetheai.com/tk.html</loc>
+  </url>
+  <url>
+    <loc>https://dontpastetheai.com/angry/tk.html</loc>
+  </url>
+  <url>
     <loc>https://dontpastetheai.com/tr.html</loc>
   </url>
   <url>
@@ -186,6 +192,9 @@
   </url>
   <url>
     <loc>https://dontpastetheai.com/student/sr-latn.html</loc>
+  </url>
+  <url>
+    <loc>https://dontpastetheai.com/student/tk.html</loc>
   </url>
   <url>
     <loc>https://dontpastetheai.com/student/tr.html</loc>

--- a/sr-latn.html
+++ b/sr-latn.html
@@ -48,6 +48,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/sr.html
+++ b/sr.html
@@ -48,6 +48,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/student/de.html
+++ b/student/de.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/es.html
+++ b/student/es.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/fa.html
+++ b/student/fa.html
@@ -52,6 +52,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/fr.html
+++ b/student/fr.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/hu.html
+++ b/student/hu.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/hy.html
+++ b/student/hy.html
@@ -51,6 +51,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/id.html
+++ b/student/id.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/index.html
+++ b/student/index.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/it.html
+++ b/student/it.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/ja.html
+++ b/student/ja.html
@@ -51,6 +51,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/ko.html
+++ b/student/ko.html
@@ -55,6 +55,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/ne.html
+++ b/student/ne.html
@@ -51,6 +51,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/pl.html
+++ b/student/pl.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/pt-br.html
+++ b/student/pt-br.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/ro.html
+++ b/student/ro.html
@@ -65,6 +65,7 @@
     <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
     <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
     <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+    <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
     <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
     <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
     <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/ru.html
+++ b/student/ru.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/sr-latn.html
+++ b/student/sr-latn.html
@@ -48,6 +48,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/sr.html
+++ b/student/sr.html
@@ -48,6 +48,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/tk.html
+++ b/student/tk.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="tk" data-page="student">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Haýyş, emeli aňyň jogabyny tabşyrma.</title>
+  <meta name="description" content="Emeli aň kursda, okuwda we işiňde saňa kömek edip biler. Seniň ýeriňe pikirlenip bilmez.">
+  <meta property="og:title" content="Haýyş, emeli aňyň jogabyny tabşyrma.">
+  <meta property="og:description" content="localhost">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-tk.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="tk_TM">
+  <meta property="og:url" content="https://dontpastetheai.com/student/tk.html">
+  <link rel="canonical" href="https://dontpastetheai.com/student/tk.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image-tk.png">
+  <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Special+Elite&family=JetBrains+Mono:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="../styles.css">
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/student/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/student/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/student/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/student/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/student/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/student/hu.html">
+  <link rel="alternate" hreflang="hy" href="https://dontpastetheai.com/student/hy.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/student/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/student/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/student/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/student/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/student/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/student/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/student/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/student/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/student/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/student/">
+  <!-- hreflang:end -->
+  <script src="../assets/translations.js" defer></script>
+  <script src="../assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>Başga dil isleýärsiňmi?</span>
+        <label class="lang" aria-label="Dil">
+          <select data-lang-select>
+            <option>TK — Türkmençe</option>
+          </select>
+        </label>
+      </div>
+      <h1><span class="yell">Emeli aňyň</span><br> jogabyny tabşyrma, haýyş.</h1>
+      <p class="lede">Men senden <em>öz</em> işiňi soranymda, seniň pikirleriňi soraýaryn.
+        Çetbota vazylyp yzyna göçürilen faýly däl. <span class="marker">Emeli aň işlemäge kömek edip
+          biler</span>. Ýöne işi seniň ýeriňe ýetirip bilmez.</p>
+    </header>
+
+    <section>
+      <h2>Näme boldy</h2>
+      <p>Taslamaň, etmeli işiň bardy. Faýly emeli aňa iberdiň, işi ýazmagyny soradyň we jogaby okaman tabşyrdyň.
+        Netijeli boldy. Emma işi seniň etmedigiň belli boldy.</p>
+      <p>Tabşyrygy ýerine ýetirmediň. Sen <strong>öz beýniňi ulanman, işiňi başgasyna berdiň</strong> we netijä öz adyňy ýazdyň.
+        Çeşmeler delil bilen gabat gelenok, eden işiň seniň iş edişiňe meňzemeýär, käte jogap doly dogry görünsede, ýalňyş. Bilýärin. Okadym.</p>
+      <p>Işi emeli aň etdi. Baha emeli aňa degişli. <em>Seniňki däl.</em></p>
+    </section>
+
+    <div class="shout">
+      Beýniňi başgasyna tabşyrmak<br><span>okamak</span> däldir.
+    </div>
+
+    <section>
+      <h2>Onuň ýerine şuny et</h2>
+      <ol>
+        <li>Emeli aňy gözleg, pikir alyşmak, kyn düşünjäni düşündirmek ýa-da ugur tapmak üçin ulan. Ony gural
+          hökmünde ulan, öz garaýşyňy emeli aňyňky çalyşma.</li>
+        <li>Onyň beren her zadyny oka. Çeşmeleri barla. Jogaby sorag et. Modeller düýbünden ýalňyşsa hem özüne
+          ynamly görünip biler, tabşyrykda heniz seniň adyň dur.</li>
+        <li>Delili özüňki et. Näme pikir edýändigiňe karar ber, <em>näme üçin</em>digini düşündir we subutnama bilen
+          golda. Tabşyryk seniň pikir ýöretmegiň, abzas sany köplügi däl.</li>
+        <li>Her sözlemi düşünüp redaktirle. Çetbotdan täzeden soraman bir pikiri düşündirip bilmeseň, tabşyrmaga
+          heniz taýyn däl.</li>
+        <li>Gural barada dogruçyl bol. Emeli aňy ulanandygyňy mälim etmegiň düzgünlerini berjaý etmek işi dogry
+          etmegiň bir bölegi. Hakykatdan özüňe degişli çala taslama, hiç düşünmedik ýalpyldawuk jogabyňdan
+          gymmatlydyr.</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>Bu emeli aňy garşytlygy däl</h2>
+      <p>Men senden bu gurallar ýokmuşyn diýip özüňi aldamagyňy soramaýaryn. Olary has gowy sorag bermek, garşy pikir
+        tapmak, pikiri synagdan geçirmek, taslamany gowulandyrmak we öwrenmek üçin ulan.
+        <strong>Gözleg. Pikir. Gözegçilik. Jedel. Sorag.</strong></p>
+      <p>Ýöne taslamany durşy bilen robota tabşyryp, çykany öz işiň ýaly diýip görkezme. Tabşyrygyň maksady resminama
+        meňzeş zat öndürmek däl. Maksat — bir zady öz sözleriň bilen aýdyp biljek derejede düşünmegiň.
+      </p>
+    </section>
+
+    <section>
+      <h2>Muny kimdir birine ibermek isleýärsiňmi?</h2>
+      <p>Talyp we okuwçy emeli aňy bilen döredilen işi okaman tabşyran bolsa, oňa şu sahypany iber. Belki indiki gezek
+        öz beýnini hem taslama goşar.</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+          data-copy-aria="{domain} adresini bukja göçür" data-copy-path="/student/tk"
+          data-copied-text="göçürildi!">dontpastetheai.com/student/tk</button></p>
+      <p class="u-center u-small u-muted u-mt-md">Göçürmek üçin bas.</p>
+    </section>
+
+    <section>
+      <h2>Asyl sahypany gözleýärsiňmi?</h2>
+      <p>Esasy sahypa emeli aň jogaplaryny okamazdan ýapyşdyrýan hemmeler üçin.</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" href="../">Emeli aňy ýapyşdyrma sahypasyna dolan</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— hormat bilen,<br>okaýşyňdan hoşnut bolmadyk mugallymyňyz</div>
+      <small><a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> we
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a>-yň ruhy
+        dogany.<br>Üns bilen ýazyldy. Ibermezden öň okaldy.</small>
+    </div>
+
+    <div class="footer">
+      <p><em>Saňa şu sahypany biri iberen bolsa: pikirlenmegiňi isleýär. Oka, çuňňur dem al we indiki sözlemi
+          özüň ýaz.</em></p>
+      <p>Bu sahypa satiradyr. Göçürmek, üýtgetmek, terjime etmek erkin.
+        <a href="https://github.com/khaosdoctor/dontquotetheai" target="_blank" rel="noopener">GitHub-da PR-lara
+          açyk</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>

--- a/student/tr.html
+++ b/student/tr.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/uk.html
+++ b/student/uk.html
@@ -48,6 +48,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/zh-cn.html
+++ b/student/zh-cn.html
@@ -56,6 +56,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/student/zh-tw.html
+++ b/student/zh-tw.html
@@ -50,6 +50,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/student/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/student/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/student/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/student/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/student/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/student/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/student/zh-cn.html">

--- a/tk.html
+++ b/tk.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="tk">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Emeli aňy ýapyşdyrma, haýyş.</title>
+  <meta name="description" content="Biri saňa bir zat soranda, öz jogabyňy iber. Emeli aňyň jogabyny däl.">
+  <meta property="og:title" content="Emeli aňy ýapyşdyrma, haýyş.">
+  <meta property="og:description" content="Biri saňa bir zat soranda, öz jogabyňy iber. Emeli aňyň jogabyny däl.">
+  <meta property="og:image" content="https://dontpastetheai.com/assets/og-image-tk.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="tk_TM">
+  <meta property="og:url" content="https://dontpastetheai.com/tk.html">
+  <link rel="canonical" href="https://dontpastetheai.com/tk.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://dontpastetheai.com/assets/og-image-tk.png">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Special+Elite&family=JetBrains+Mono:wght@400;500;700;800&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <!-- hreflang:start (managed by scripts/sync-hreflang.mjs — do not edit by hand) -->
+  <link rel="alternate" hreflang="de" href="https://dontpastetheai.com/de.html">
+  <link rel="alternate" hreflang="en" href="https://dontpastetheai.com/">
+  <link rel="alternate" hreflang="es" href="https://dontpastetheai.com/es.html">
+  <link rel="alternate" hreflang="fa" href="https://dontpastetheai.com/fa.html">
+  <link rel="alternate" hreflang="fr" href="https://dontpastetheai.com/fr.html">
+  <link rel="alternate" hreflang="hu" href="https://dontpastetheai.com/hu.html">
+  <link rel="alternate" hreflang="hy" href="https://dontpastetheai.com/hy.html">
+  <link rel="alternate" hreflang="id" href="https://dontpastetheai.com/id.html">
+  <link rel="alternate" hreflang="it" href="https://dontpastetheai.com/it.html">
+  <link rel="alternate" hreflang="ja" href="https://dontpastetheai.com/ja.html">
+  <link rel="alternate" hreflang="ko" href="https://dontpastetheai.com/ko.html">
+  <link rel="alternate" hreflang="ne" href="https://dontpastetheai.com/ne.html">
+  <link rel="alternate" hreflang="pl" href="https://dontpastetheai.com/pl.html">
+  <link rel="alternate" hreflang="pt-BR" href="https://dontpastetheai.com/pt-br.html">
+  <link rel="alternate" hreflang="ro" href="https://dontpastetheai.com/ro.html">
+  <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
+  <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
+  <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
+  <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
+  <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
+  <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">
+  <link rel="alternate" hreflang="zh-TW" href="https://dontpastetheai.com/zh-tw.html">
+  <link rel="alternate" hreflang="x-default" href="https://dontpastetheai.com/">
+  <!-- hreflang:end -->
+  <script src="assets/translations.js" defer></script>
+  <script src="assets/copy.js" defer></script>
+</head>
+
+<body>
+  <main class="sheet">
+
+    <header>
+      <div class="doc-meta">
+        <span>Başga dil isleýärsiňmi?</span>
+        <label class="lang" aria-label="Dil">
+          <select data-lang-select>
+            <option>TK — Türkmençe</option>
+          </select>
+        </label>
+      </div>
+      <h1>Haýyş,<br><span class="yell">emeli aňy</span> ýapyşdyrma.</h1>
+      <p class="lede">Biri saňa bir zat soranda, olar <em>seniň</em> jogabyňy isleýär.
+        <span class="marker">ChatGPT tekstiniň uzyn diwaryny</span> däl. Robot hakly bolsa-da, adamdan çykan gysga jogap
+        elmydama robatyňkyndan gymmatlydyr.</p>
+    </header>
+
+    <section>
+      <h2>Näme boldy</h2>
+      <p>Biri saňa tüýs ýürekden sorag berdi. Sen ony çetbota atdyň, jogaby göçürdiň we yzyna iberdiň.
+        Çalt boldy. Peýdaly gördüň. Ýöne beýle däl.</p>
+      <p>Beýle görünmese-de, aňyrky tarapdaky adamyň <strong>seniňki bilen birmeňzeş gurallary bar</strong>. Olara adaty
+        jogap gerek bolsa, ony birnäçe sekuntda özleri alardylar. Olar <em>saňa</em> ýüz tutdular, çünki seniň pikiriňi
+        islediler... Seniň tejribäňi, pikiriňi, baha bermegiňi.</p>
+
+      <p>Dünýä okamagy ýa içgin oýlanmagy islemeýän adamlar bilen doly. Olardan biri bolma.</p>
+    </section>
+
+    <section>
+      <h2>Onuň ýerine şuny et</h2>
+      <ol>
+        <li>Emeli aňy ulanyp bilersiň. Hakykatdan! Taslama üçin ajaýyp gural. Diňe <strong>onuň saňa berenini oka
+        </strong>, soňra öz pikiriňi ýaz ýa-da teksti redaktirle. Onuň bilen jogabyň arasynda köprü bolma.</li>
+        <li>Soraga hakykatdan jogap berýän bölegini saýla, galanyny taşla. Üç sözlem ýeterlik, göçürilen bolsa-da
+          azyndan okansyň.</li>
+        <li>Modeliň jogabyndaky bir bölek hakykatdan peýdaly bolsa, ony sitata getir we <em>näme üçin</em>digini düşündir.
+          <span class="marker"><em>"Claude-dan soradym, şu ýeri logikasy dogry:"</em></span>.
+        </li>
+        <li>Goşar ýaly zadyň ýok bolsa, şeýle diý. <span class="marker"><em>"Bu barada aýratyn pikirim
+              ýok"</em></span>. Dymmagyň özi-de bir usul.
+        </li>
+      </ol>
+    </section>
+
+    <section>
+<h2>Muny birine ibermek isleýärsiňmi?</h2>
+      <p>Biri şahsy hatlaryňa, Slack-e ýa-da kod synyňa modelden çykan uly tekst diwaryny goýan bolsa, oňa şu sahypany
+        iberip bilersiň. Wagyz etmek gerek däl.</p>
+      <p class="u-center u-mt-lg"><button id="copyBtn" type="button" class="url-tag-big"
+          data-copy-aria="{domain} adresini bukja göçür" data-copied-text="göçürildi!">dontpastetheai.com</button></p>
+      <p class="u-center u-small u-muted u-mt-md">Göçürmek üçin bas.</p>
+    </section>
+
+    <section>
+      <h2>Has gödek görnüşini isleýärsiňmi?</h2>
+      <p>Kimdir birine <em>duýgular</em> gatyşan görnüşini ibermek isleseň, ol hem taýýar!</p>
+      <p class="u-center u-mt-lg"><a class="cta-angry" data-variant-toggle href="angry/index.html">Meni gaharly görnüşe
+          geçir →</a></p>
+      <p class="u-center u-small u-muted u-mt-md">Ýolbaşçyňa ibermek üçin amatly bolmaz, ýöne özüň bil</p>
+    </section>
+
+    <section>
+      <h2>Mugallymmyň?</h2>
+      <p>Talyplaryňyz we okuwçylaryňyz size emeli aň tarapyndan ýazylan iş iberse, olara şu sahypany iberip bilersiňiz:</p>
+      <p class="u-center u-mt-lg"><a class="cta-calm" data-student-toggle href="student/">Olara şu sapagy iber</a></p>
+    </section>
+
+    <div class="signature">
+      <div class="name">— ...söýgi bilenmi? <br>Hemme kişi</div>
+      <small><a href="https://nohello.net" target="_blank" rel="noopener">nohello.net</a> we
+        <a href="https://dontasktoask.com" target="_blank" rel="noopener">dontasktoask.com</a>-yň ruhy dogany.<br>
+        tötänleýin biri tarapyndan ýazyldy (<a href="https://github.com/khaosdoctor/dontquotetheai/issues/31" target="_blank" rel="noopener">ynanmaýarsyň, şeýlemi?</a>). Edil öňkü günlerdäki ýaly.</small>
+    </div>
+
+    <div class="footer">
+      <p><em>Biri saňa şu sahypany iberen bolsa: pikirlenmegiňi isleýär. Oka, çuňňur dem al we indiki
+          jogabyňy özüň ýaz.</em></p>
+      <p>Bu sahypa satiradyr (duýmadyk bolsaň). Göçürmek, üýtgetmek, terjime etmek erkin —
+        <a href="https://github.com/khaosdoctor/dontquotetheai" target="_blank" rel="noopener">GitHubda PRlara
+          açyk</a>.
+      </p>
+    </div>
+
+  </main>
+</body>
+
+</html>

--- a/tr.html
+++ b/tr.html
@@ -45,6 +45,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/uk.html
+++ b/uk.html
@@ -48,6 +48,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/zh-cn.html
+++ b/zh-cn.html
@@ -76,6 +76,7 @@
         <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
         <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
         <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+        <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
         <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
         <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
         <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">

--- a/zh-tw.html
+++ b/zh-tw.html
@@ -48,6 +48,7 @@
   <link rel="alternate" hreflang="ru" href="https://dontpastetheai.com/ru.html">
   <link rel="alternate" hreflang="sr" href="https://dontpastetheai.com/sr.html">
   <link rel="alternate" hreflang="sr-Latn" href="https://dontpastetheai.com/sr-latn.html">
+  <link rel="alternate" hreflang="tk" href="https://dontpastetheai.com/tk.html">
   <link rel="alternate" hreflang="tr" href="https://dontpastetheai.com/tr.html">
   <link rel="alternate" hreflang="uk" href="https://dontpastetheai.com/uk.html">
   <link rel="alternate" hreflang="zh-CN" href="https://dontpastetheai.com/zh-cn.html">


### PR DESCRIPTION
## Translation PR

**Language code (BCP 47, lowercase):** `tk`

- Smooth, angry, and student pages in Turkmen
- Register tk in assets/translations.json
- Add og-image-tk.svg social card
- Sync hreflang links and sitemap.xml

Please confirm:

- [x] I translated **both** the smooth version (`tk.html`) **and** the angry version (`angry/tk.html`).
- [x] I added an entry for my language to `assets/translations.json` (with `code`, `hreflang`, `label`, `file`).
- [x] I added a `<link rel="alternate" hreflang="...">` tag for my language to **every other HTML file** (smooth → smooth URLs, angry → angry URLs). See `TRANSLATING.md` for the full list.
- [x] My files have the correct `<html lang="...">`, `<link rel="canonical">`, `<meta property="og:url">`, and `<meta name="twitter:image">` pointing at `https://dontpastetheai.com/...`.
- [x] I created `assets/og-image-tk.svg` (and `.png` if I could render it — otherwise SVG only is fine, just call it out below).
- [x] I updated the no-JS fallback `<option>` inside `<select data-lang-select>` so my language appears with its label.
- [ ] The **Validate translations** GitHub Action passed on this PR.

**Notes / caveats:**

- SVG only, no PNG — couldn't render locally (`rsvg-convert` not installed). CI should render `og-image-tk.png` on merge.
- AI term uses `emeli aň`; please check the `ň` glyph in `Special Elite` on the card and pages.
- Fully human translated.
- If there is issue with this pr, write comments please

---

Thanks for accepting this PR  💛